### PR TITLE
[team-08][iOS] 메인화면 뷰 만들기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,259 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/gradle,xcode,intellij,java,swift
+# Edit at https://www.toptal.com/developers/gitignore?templates=gradle,xcode,intellij,java,swift
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Xcode ###
+
+## Xcode 8 and earlier
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# End of https://www.toptal.com/developers/gitignore/api/gradle,xcode,intellij,java,swift

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # todo-list
-그룹 프로젝트 #1
+> 8조
+
+## 팀원
+
+|iOS|BE|
+|---|---|
+|[dale](https://github.com/sungju-kim)|[포키](https://github.com/Seokho-Ham)|
+|[sally](https://github.com/sally4405)|[dave](https://github.com/nak253)|
+
+
+## Ground Rule
+[wiki](https://github.com/sally4405/todo-list/wiki/Ground-Rule)

--- a/README.md
+++ b/README.md
@@ -9,5 +9,17 @@
 |[sally](https://github.com/sally4405)|[dave](https://github.com/nak253)|
 
 
-## Ground Rule
-[wiki](https://github.com/sally4405/todo-list/wiki/Ground-Rule)
+## 작업 내용
+
+## 결과물
+
+## 고민과 해결과정
+
+## 남아있는 문제
+
+
+## Document
+
+[기획서](https://www.figma.com/proto/vYGeE8xND8ZRkesKHLIc1b/%EB%AA%A8%EB%B0%94%EC%9D%BC_%ED%88%AC%EB%91%90%EB%A6%AC%EC%8A%A4%ED%8A%B8?node-id=94%3A418&scaling=contain&page-id=94%3A414)
+[Ground Rule](https://github.com/sally4405/todo-list/wiki/Ground-Rule)
+[API](https://app.swaggerhub.com/apis-docs/Seokho-Ham/todolist/1.0.0)

--- a/iOS/TodoList.xcodeproj/project.pbxproj
+++ b/iOS/TodoList.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		6F41D5AA27FAE04A00EA3FA8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6F41D5A827FAE04A00EA3FA8 /* Main.storyboard */; };
 		6F41D5AC27FAE04B00EA3FA8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */; };
 		6F41D5AF27FAE04B00EA3FA8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6F41D5AD27FAE04B00EA3FA8 /* LaunchScreen.storyboard */; };
+		6F41D5BB27FBD6F700EA3FA8 /* TaskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5BA27FBD6F700EA3FA8 /* TaskListView.swift */; };
+		6F41D5BD27FBD70700EA3FA8 /* TaskListView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6F41D5BC27FBD70700EA3FA8 /* TaskListView.xib */; };
+		6F41D5C127FC085C00EA3FA8 /* TaskListBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5C027FC085C00EA3FA8 /* TaskListBoardViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +27,9 @@
 		6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6F41D5AE27FAE04B00EA3FA8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6F41D5B027FAE04B00EA3FA8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6F41D5BA27FBD6F700EA3FA8 /* TaskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListView.swift; sourceTree = "<group>"; };
+		6F41D5BC27FBD70700EA3FA8 /* TaskListView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TaskListView.xib; sourceTree = "<group>"; };
+		6F41D5C027FC085C00EA3FA8 /* TaskListBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListBoardViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +66,9 @@
 				6F41D5A427FAE04A00EA3FA8 /* SceneDelegate.swift */,
 				6F41D5A627FAE04A00EA3FA8 /* ViewController.swift */,
 				6F41D5A827FAE04A00EA3FA8 /* Main.storyboard */,
+				6F41D5C027FC085C00EA3FA8 /* TaskListBoardViewController.swift */,
+				6F41D5BA27FBD6F700EA3FA8 /* TaskListView.swift */,
+				6F41D5BC27FBD70700EA3FA8 /* TaskListView.xib */,
 				6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */,
 				6F41D5AD27FAE04B00EA3FA8 /* LaunchScreen.storyboard */,
 				6F41D5B027FAE04B00EA3FA8 /* Info.plist */,
@@ -125,6 +134,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F41D5BD27FBD70700EA3FA8 /* TaskListView.xib in Resources */,
 				6F41D5AF27FAE04B00EA3FA8 /* LaunchScreen.storyboard in Resources */,
 				6F41D5AC27FAE04B00EA3FA8 /* Assets.xcassets in Resources */,
 				6F41D5AA27FAE04A00EA3FA8 /* Main.storyboard in Resources */,
@@ -138,7 +148,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F41D5C127FC085C00EA3FA8 /* TaskListBoardViewController.swift in Sources */,
 				6F41D5A727FAE04A00EA3FA8 /* ViewController.swift in Sources */,
+				6F41D5BB27FBD6F700EA3FA8 /* TaskListView.swift in Sources */,
 				6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */,
 				6F41D5A527FAE04A00EA3FA8 /* SceneDelegate.swift in Sources */,
 			);

--- a/iOS/TodoList.xcodeproj/project.pbxproj
+++ b/iOS/TodoList.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6C22959727FD64C800381DA2 /* EditCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C22959627FD64C800381DA2 /* EditCardView.swift */; };
+		6C22959927FD64DB00381DA2 /* EditCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6C22959827FD64DB00381DA2 /* EditCardView.xib */; };
 		6CF3C10927FC2907003B4803 /* TaskCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */; };
 		6CF3C10A27FC2907003B4803 /* TaskCardViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */; };
 		6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A227FAE04A00EA3FA8 /* AppDelegate.swift */; };
@@ -21,6 +23,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6C22959627FD64C800381DA2 /* EditCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCardView.swift; sourceTree = "<group>"; };
+		6C22959827FD64DB00381DA2 /* EditCardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditCardView.xib; sourceTree = "<group>"; };
 		6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCardViewCell.swift; sourceTree = "<group>"; };
 		6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TaskCardViewCell.xib; sourceTree = "<group>"; };
 		6F41D59F27FAE04A00EA3FA8 /* TodoList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TodoList.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,6 +79,8 @@
 				6F41D5BC27FBD70700EA3FA8 /* TaskListView.xib */,
 				6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */,
 				6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */,
+				6C22959627FD64C800381DA2 /* EditCardView.swift */,
+				6C22959827FD64DB00381DA2 /* EditCardView.xib */,
 				6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */,
 				6F41D5AD27FAE04B00EA3FA8 /* LaunchScreen.storyboard */,
 				6F41D5B027FAE04B00EA3FA8 /* Info.plist */,
@@ -142,6 +148,7 @@
 			files = (
 				6F41D5BD27FBD70700EA3FA8 /* TaskListView.xib in Resources */,
 				6CF3C10A27FC2907003B4803 /* TaskCardViewCell.xib in Resources */,
+				6C22959927FD64DB00381DA2 /* EditCardView.xib in Resources */,
 				6F41D5AF27FAE04B00EA3FA8 /* LaunchScreen.storyboard in Resources */,
 				6F41D5AC27FAE04B00EA3FA8 /* Assets.xcassets in Resources */,
 				6F41D5AA27FAE04A00EA3FA8 /* Main.storyboard in Resources */,
@@ -157,6 +164,7 @@
 			files = (
 				6F41D5C127FC085C00EA3FA8 /* TaskListBoardViewController.swift in Sources */,
 				6F41D5A727FAE04A00EA3FA8 /* ViewController.swift in Sources */,
+				6C22959727FD64C800381DA2 /* EditCardView.swift in Sources */,
 				6F41D5BB27FBD6F700EA3FA8 /* TaskListView.swift in Sources */,
 				6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */,
 				6F41D5A527FAE04A00EA3FA8 /* SceneDelegate.swift in Sources */,

--- a/iOS/TodoList.xcodeproj/project.pbxproj
+++ b/iOS/TodoList.xcodeproj/project.pbxproj
@@ -1,0 +1,361 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A227FAE04A00EA3FA8 /* AppDelegate.swift */; };
+		6F41D5A527FAE04A00EA3FA8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A427FAE04A00EA3FA8 /* SceneDelegate.swift */; };
+		6F41D5A727FAE04A00EA3FA8 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A627FAE04A00EA3FA8 /* ViewController.swift */; };
+		6F41D5AA27FAE04A00EA3FA8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6F41D5A827FAE04A00EA3FA8 /* Main.storyboard */; };
+		6F41D5AC27FAE04B00EA3FA8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */; };
+		6F41D5AF27FAE04B00EA3FA8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6F41D5AD27FAE04B00EA3FA8 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		6F41D59F27FAE04A00EA3FA8 /* TodoList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TodoList.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F41D5A227FAE04A00EA3FA8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6F41D5A427FAE04A00EA3FA8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		6F41D5A627FAE04A00EA3FA8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		6F41D5A927FAE04A00EA3FA8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6F41D5AE27FAE04B00EA3FA8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		6F41D5B027FAE04B00EA3FA8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6F41D59C27FAE04A00EA3FA8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6F41D59627FAE04A00EA3FA8 = {
+			isa = PBXGroup;
+			children = (
+				6F41D5A127FAE04A00EA3FA8 /* TodoList */,
+				6F41D5A027FAE04A00EA3FA8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6F41D5A027FAE04A00EA3FA8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6F41D59F27FAE04A00EA3FA8 /* TodoList.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6F41D5A127FAE04A00EA3FA8 /* TodoList */ = {
+			isa = PBXGroup;
+			children = (
+				6F41D5A227FAE04A00EA3FA8 /* AppDelegate.swift */,
+				6F41D5A427FAE04A00EA3FA8 /* SceneDelegate.swift */,
+				6F41D5A627FAE04A00EA3FA8 /* ViewController.swift */,
+				6F41D5A827FAE04A00EA3FA8 /* Main.storyboard */,
+				6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */,
+				6F41D5AD27FAE04B00EA3FA8 /* LaunchScreen.storyboard */,
+				6F41D5B027FAE04B00EA3FA8 /* Info.plist */,
+			);
+			path = TodoList;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6F41D59E27FAE04A00EA3FA8 /* TodoList */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6F41D5B327FAE04B00EA3FA8 /* Build configuration list for PBXNativeTarget "TodoList" */;
+			buildPhases = (
+				6F41D59B27FAE04A00EA3FA8 /* Sources */,
+				6F41D59C27FAE04A00EA3FA8 /* Frameworks */,
+				6F41D59D27FAE04A00EA3FA8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TodoList;
+			productName = TodoList;
+			productReference = 6F41D59F27FAE04A00EA3FA8 /* TodoList.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6F41D59727FAE04A00EA3FA8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1330;
+				LastUpgradeCheck = 1330;
+				TargetAttributes = {
+					6F41D59E27FAE04A00EA3FA8 = {
+						CreatedOnToolsVersion = 13.3;
+					};
+				};
+			};
+			buildConfigurationList = 6F41D59A27FAE04A00EA3FA8 /* Build configuration list for PBXProject "TodoList" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6F41D59627FAE04A00EA3FA8;
+			productRefGroup = 6F41D5A027FAE04A00EA3FA8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6F41D59E27FAE04A00EA3FA8 /* TodoList */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6F41D59D27FAE04A00EA3FA8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F41D5AF27FAE04B00EA3FA8 /* LaunchScreen.storyboard in Resources */,
+				6F41D5AC27FAE04B00EA3FA8 /* Assets.xcassets in Resources */,
+				6F41D5AA27FAE04A00EA3FA8 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6F41D59B27FAE04A00EA3FA8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F41D5A727FAE04A00EA3FA8 /* ViewController.swift in Sources */,
+				6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */,
+				6F41D5A527FAE04A00EA3FA8 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		6F41D5A827FAE04A00EA3FA8 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6F41D5A927FAE04A00EA3FA8 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		6F41D5AD27FAE04B00EA3FA8 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6F41D5AE27FAE04B00EA3FA8 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		6F41D5B127FAE04B00EA3FA8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		6F41D5B227FAE04B00EA3FA8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6F41D5B427FAE04B00EA3FA8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TodoList/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = codesquad.2022.groupProject.TodoList;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6F41D5B527FAE04B00EA3FA8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TodoList/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = codesquad.2022.groupProject.TodoList;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6F41D59A27FAE04A00EA3FA8 /* Build configuration list for PBXProject "TodoList" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6F41D5B127FAE04B00EA3FA8 /* Debug */,
+				6F41D5B227FAE04B00EA3FA8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6F41D5B327FAE04B00EA3FA8 /* Build configuration list for PBXNativeTarget "TodoList" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6F41D5B427FAE04B00EA3FA8 /* Debug */,
+				6F41D5B527FAE04B00EA3FA8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6F41D59727FAE04A00EA3FA8 /* Project object */;
+}

--- a/iOS/TodoList.xcodeproj/project.pbxproj
+++ b/iOS/TodoList.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6CF3C10927FC2907003B4803 /* TaskCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */; };
+		6CF3C10A27FC2907003B4803 /* TaskCardViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */; };
 		6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A227FAE04A00EA3FA8 /* AppDelegate.swift */; };
 		6F41D5A527FAE04A00EA3FA8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A427FAE04A00EA3FA8 /* SceneDelegate.swift */; };
 		6F41D5A727FAE04A00EA3FA8 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A627FAE04A00EA3FA8 /* ViewController.swift */; };
@@ -19,6 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCardViewCell.swift; sourceTree = "<group>"; };
+		6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TaskCardViewCell.xib; sourceTree = "<group>"; };
 		6F41D59F27FAE04A00EA3FA8 /* TodoList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TodoList.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F41D5A227FAE04A00EA3FA8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6F41D5A427FAE04A00EA3FA8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +73,8 @@
 				6F41D5C027FC085C00EA3FA8 /* TaskListBoardViewController.swift */,
 				6F41D5BA27FBD6F700EA3FA8 /* TaskListView.swift */,
 				6F41D5BC27FBD70700EA3FA8 /* TaskListView.xib */,
+				6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */,
+				6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */,
 				6F41D5AB27FAE04B00EA3FA8 /* Assets.xcassets */,
 				6F41D5AD27FAE04B00EA3FA8 /* LaunchScreen.storyboard */,
 				6F41D5B027FAE04B00EA3FA8 /* Info.plist */,
@@ -135,6 +141,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6F41D5BD27FBD70700EA3FA8 /* TaskListView.xib in Resources */,
+				6CF3C10A27FC2907003B4803 /* TaskCardViewCell.xib in Resources */,
 				6F41D5AF27FAE04B00EA3FA8 /* LaunchScreen.storyboard in Resources */,
 				6F41D5AC27FAE04B00EA3FA8 /* Assets.xcassets in Resources */,
 				6F41D5AA27FAE04A00EA3FA8 /* Main.storyboard in Resources */,
@@ -153,6 +160,7 @@
 				6F41D5BB27FBD6F700EA3FA8 /* TaskListView.swift in Sources */,
 				6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */,
 				6F41D5A527FAE04A00EA3FA8 /* SceneDelegate.swift in Sources */,
+				6CF3C10927FC2907003B4803 /* TaskCardViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/TodoList.xcodeproj/project.pbxproj
+++ b/iOS/TodoList.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6C22959727FD64C800381DA2 /* EditCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C22959627FD64C800381DA2 /* EditCardView.swift */; };
 		6C22959927FD64DB00381DA2 /* EditCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6C22959827FD64DB00381DA2 /* EditCardView.xib */; };
+		6C22959B27FD698000381DA2 /* EditCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C22959A27FD698000381DA2 /* EditCardViewController.swift */; };
 		6CF3C10927FC2907003B4803 /* TaskCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */; };
 		6CF3C10A27FC2907003B4803 /* TaskCardViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */; };
 		6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41D5A227FAE04A00EA3FA8 /* AppDelegate.swift */; };
@@ -25,6 +26,7 @@
 /* Begin PBXFileReference section */
 		6C22959627FD64C800381DA2 /* EditCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCardView.swift; sourceTree = "<group>"; };
 		6C22959827FD64DB00381DA2 /* EditCardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditCardView.xib; sourceTree = "<group>"; };
+		6C22959A27FD698000381DA2 /* EditCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCardViewController.swift; sourceTree = "<group>"; };
 		6CF3C10727FC2907003B4803 /* TaskCardViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCardViewCell.swift; sourceTree = "<group>"; };
 		6CF3C10827FC2907003B4803 /* TaskCardViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TaskCardViewCell.xib; sourceTree = "<group>"; };
 		6F41D59F27FAE04A00EA3FA8 /* TodoList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TodoList.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -74,6 +76,7 @@
 				6F41D5A427FAE04A00EA3FA8 /* SceneDelegate.swift */,
 				6F41D5A627FAE04A00EA3FA8 /* ViewController.swift */,
 				6F41D5A827FAE04A00EA3FA8 /* Main.storyboard */,
+				6C22959A27FD698000381DA2 /* EditCardViewController.swift */,
 				6F41D5C027FC085C00EA3FA8 /* TaskListBoardViewController.swift */,
 				6F41D5BA27FBD6F700EA3FA8 /* TaskListView.swift */,
 				6F41D5BC27FBD70700EA3FA8 /* TaskListView.xib */,
@@ -168,6 +171,7 @@
 				6F41D5BB27FBD6F700EA3FA8 /* TaskListView.swift in Sources */,
 				6F41D5A327FAE04A00EA3FA8 /* AppDelegate.swift in Sources */,
 				6F41D5A527FAE04A00EA3FA8 /* SceneDelegate.swift in Sources */,
+				6C22959B27FD698000381DA2 /* EditCardViewController.swift in Sources */,
 				6CF3C10927FC2907003B4803 /* TaskCardViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/TodoList.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/iOS/TodoList.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/iOS/TodoList.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/iOS/TodoList.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/iOS/TodoList/AppDelegate.swift
+++ b/iOS/TodoList/AppDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
+
+}
+

--- a/iOS/TodoList/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/iOS/TodoList/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/TodoList/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOS/TodoList/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/TodoList/Assets.xcassets/Contents.json
+++ b/iOS/TodoList/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/TodoList/Base.lproj/LaunchScreen.storyboard
+++ b/iOS/TodoList/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/iOS/TodoList/Base.lproj/Main.storyboard
+++ b/iOS/TodoList/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/iOS/TodoList/Base.lproj/Main.storyboard
+++ b/iOS/TodoList/Base.lproj/Main.storyboard
@@ -29,12 +29,13 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="stackViewTrailing" destination="zks-zh-1b5" id="lL5-3a-SUS"/>
                         <outlet property="taskListStackView" destination="q3x-H0-srJ" id="b2L-zg-6TB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="138.69346733668343" y="137.41007194244605"/>
+            <point key="canvasLocation" x="138.12949640287772" y="137.1859296482412"/>
         </scene>
     </scenes>
 </document>

--- a/iOS/TodoList/Base.lproj/Main.storyboard
+++ b/iOS/TodoList/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,17 +19,44 @@
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q3x-H0-srJ">
                                 <rect key="frame" x="48" y="147" width="816" height="637"/>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xjx-qt-nUY">
+                                <rect key="frame" x="1147" y="55" width="17" height="11"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="17" id="YZE-D9-g8k"/>
+                                    <constraint firstAttribute="height" constant="11" id="drV-Lw-9Od"/>
+                                </constraints>
+                                <color key="tintColor" red="0.0039215686274509803" green="0.0039215686274509803" blue="0.0039215686274509803" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" image="line.horizontal.3" catalog="system"/>
+                                <connections>
+                                    <action selector="actionFlowButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qhZ-eb-zu8"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TO-DO LIST" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JvC-rN-hhd">
+                                <rect key="frame" x="48" y="37" width="171" height="46"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="46" id="MOq-Ud-5sp"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Xjx-qt-nUY" secondAttribute="trailing" constant="30" id="BSi-tT-Tsa"/>
+                            <constraint firstItem="JvC-rN-hhd" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="13" id="Kmw-pK-CWi"/>
                             <constraint firstItem="q3x-H0-srJ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="48" id="SBh-xI-koj"/>
                             <constraint firstItem="q3x-H0-srJ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="123" id="YAa-7k-4oZ"/>
+                            <constraint firstItem="Xjx-qt-nUY" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="31" id="a1E-GN-Hqa"/>
+                            <constraint firstItem="JvC-rN-hhd" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="48" id="o3J-Oe-iig"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="q3x-H0-srJ" secondAttribute="bottom" constant="30" id="r0p-ZZ-XtZ"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="q3x-H0-srJ" secondAttribute="trailing" constant="330" id="zks-zh-1b5"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="actionFlowButton" destination="Xjx-qt-nUY" id="igO-MJ-sCW"/>
                         <outlet property="stackViewTrailing" destination="zks-zh-1b5" id="lL5-3a-SUS"/>
                         <outlet property="taskListStackView" destination="q3x-H0-srJ" id="b2L-zg-6TB"/>
                     </connections>
@@ -37,5 +65,36 @@
             </objects>
             <point key="canvasLocation" x="138.12949640287772" y="137.1859296482412"/>
         </scene>
+        <!--Edit Card View Controller-->
+        <scene sceneID="xs8-kx-v8s">
+            <objects>
+                <viewController storyboardIdentifier="popVC" id="wYC-pF-Ein" customClass="EditCardViewController" customModule="TodoList" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ia6-xm-5ws">
+                        <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="70t-Qa-EDn">
+                                <rect key="frame" x="397" y="330" width="400" height="175"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="uec-tf-4EG"/>
+                        <color key="backgroundColor" red="0.0039215686274509803" green="0.0039215686274509803" blue="0.0039215686274509803" alpha="0.40000000000000002" colorSpace="custom" customColorSpace="displayP3"/>
+                    </view>
+                    <connections>
+                        <outlet property="centerView" destination="70t-Qa-EDn" id="a5i-Yj-ute"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4zZ-Fi-tA0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="830" y="137"/>
+        </scene>
     </scenes>
+    <resources>
+        <image name="line.horizontal.3" catalog="system" width="128" height="64"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOS/TodoList/Base.lproj/Main.storyboard
+++ b/iOS/TodoList/Base.lproj/Main.storyboard
@@ -4,7 +4,6 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,13 +17,14 @@
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i6N-Cf-0Uc">
                                 <rect key="frame" x="48" y="147" width="816" height="642"/>
+                                <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <segue destination="r1y-LQ-nwm" kind="embed" id="vby-Nt-F2Z"/>
                                 </connections>
                             </containerView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="i6N-Cf-0Uc" secondAttribute="trailing" constant="330" id="Api-3i-Ku8"/>
                             <constraint firstItem="i6N-Cf-0Uc" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="48" id="fsb-p8-Q91"/>
@@ -45,17 +45,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="816" height="642"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="n4q-Dp-ew9"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IRI-WL-E10" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-17" y="787"/>
+            <point key="canvasLocation" x="-17.08542713567839" y="786.33093525179856"/>
         </scene>
     </scenes>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/iOS/TodoList/Base.lproj/Main.storyboard
+++ b/iOS/TodoList/Base.lproj/Main.storyboard
@@ -1,24 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="ipad11_0rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="TodoList" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i6N-Cf-0Uc">
+                                <rect key="frame" x="91" y="215" width="390" height="287"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                <connections>
+                                    <segue destination="r1y-LQ-nwm" kind="embed" id="vby-Nt-F2Z"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="138.69346733668343" y="137.41007194244605"/>
+        </scene>
+        <!--Task List Board View Controller-->
+        <scene sceneID="ZjA-Dt-iZ0">
+            <objects>
+                <viewController id="r1y-LQ-nwm" customClass="TaskListBoardViewController" customModule="TodoList" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="qNF-ro-SWM">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="287"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="IRI-WL-E10" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-71" y="640"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOS/TodoList/Base.lproj/Main.storyboard
+++ b/iOS/TodoList/Base.lproj/Main.storyboard
@@ -16,9 +16,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i6N-Cf-0Uc">
-                                <rect key="frame" x="91" y="215" width="390" height="287"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i6N-Cf-0Uc">
+                                <rect key="frame" x="48" y="147" width="816" height="642"/>
                                 <connections>
                                     <segue destination="r1y-LQ-nwm" kind="embed" id="vby-Nt-F2Z"/>
                                 </connections>
@@ -26,6 +25,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="i6N-Cf-0Uc" secondAttribute="trailing" constant="330" id="Api-3i-Ku8"/>
+                            <constraint firstItem="i6N-Cf-0Uc" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="48" id="fsb-p8-Q91"/>
+                            <constraint firstItem="i6N-Cf-0Uc" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="123" id="qDz-ow-Qht"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="i6N-Cf-0Uc" secondAttribute="bottom" constant="25" id="sfP-wX-UFr"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -37,14 +42,15 @@
             <objects>
                 <viewController id="r1y-LQ-nwm" customClass="TaskListBoardViewController" customModule="TodoList" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qNF-ro-SWM">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="287"/>
+                        <rect key="frame" x="0.0" y="0.0" width="816" height="642"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="n4q-Dp-ew9"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IRI-WL-E10" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-71" y="640"/>
+            <point key="canvasLocation" x="-17" y="787"/>
         </scene>
     </scenes>
     <resources>

--- a/iOS/TodoList/Base.lproj/Main.storyboard
+++ b/iOS/TodoList/Base.lproj/Main.storyboard
@@ -15,42 +15,26 @@
                         <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i6N-Cf-0Uc">
-                                <rect key="frame" x="48" y="147" width="816" height="642"/>
-                                <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <connections>
-                                    <segue destination="r1y-LQ-nwm" kind="embed" id="vby-Nt-F2Z"/>
-                                </connections>
-                            </containerView>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q3x-H0-srJ">
+                                <rect key="frame" x="48" y="147" width="816" height="637"/>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="i6N-Cf-0Uc" secondAttribute="trailing" constant="330" id="Api-3i-Ku8"/>
-                            <constraint firstItem="i6N-Cf-0Uc" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="48" id="fsb-p8-Q91"/>
-                            <constraint firstItem="i6N-Cf-0Uc" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="123" id="qDz-ow-Qht"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="i6N-Cf-0Uc" secondAttribute="bottom" constant="25" id="sfP-wX-UFr"/>
+                            <constraint firstItem="q3x-H0-srJ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="48" id="SBh-xI-koj"/>
+                            <constraint firstItem="q3x-H0-srJ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="123" id="YAa-7k-4oZ"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="q3x-H0-srJ" secondAttribute="bottom" constant="30" id="r0p-ZZ-XtZ"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="q3x-H0-srJ" secondAttribute="trailing" constant="330" id="zks-zh-1b5"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="taskListStackView" destination="q3x-H0-srJ" id="b2L-zg-6TB"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="138.69346733668343" y="137.41007194244605"/>
-        </scene>
-        <!--Task List Board View Controller-->
-        <scene sceneID="ZjA-Dt-iZ0">
-            <objects>
-                <viewController id="r1y-LQ-nwm" customClass="TaskListBoardViewController" customModule="TodoList" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="qNF-ro-SWM">
-                        <rect key="frame" x="0.0" y="0.0" width="816" height="642"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <viewLayoutGuide key="safeArea" id="n4q-Dp-ew9"/>
-                        <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="IRI-WL-E10" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-17.08542713567839" y="786.33093525179856"/>
         </scene>
     </scenes>
 </document>

--- a/iOS/TodoList/EditCardView.swift
+++ b/iOS/TodoList/EditCardView.swift
@@ -1,0 +1,12 @@
+//
+//  EditCardView.swift
+//  TodoList
+//
+//  Created by dale on 2022/04/06.
+//
+
+import UIKit
+
+class EditCardView: UIView {
+
+}

--- a/iOS/TodoList/EditCardView.xib
+++ b/iOS/TodoList/EditCardView.xib
@@ -39,7 +39,7 @@
                     </constraints>
                     <color key="textColor" systemColor="systemGray3Color"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <textInputTraits key="textInputTraits"/>
+                    <textInputTraits key="textInputTraits" smartInsertDeleteType="no"/>
                 </textField>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AsX-pi-UNx">
                     <rect key="frame" x="160" y="119" width="108" height="40"/>
@@ -86,22 +86,22 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="L9r-Qn-qYV" secondAttribute="trailing" constant="16" id="1us-dh-jHc"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="kt7-TL-hNl" secondAttribute="bottom" constant="16" id="5xs-Qv-XzP"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="kt7-TL-hNl" secondAttribute="trailing" constant="16" id="7cd-EB-uId"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="AsX-pi-UNx" secondAttribute="bottom" constant="16" id="JsL-rU-e7w"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="gBo-ia-khY" secondAttribute="trailing" constant="16" id="MF0-O3-sS0"/>
+                <constraint firstAttribute="trailing" secondItem="L9r-Qn-qYV" secondAttribute="trailing" constant="16" id="1us-dh-jHc"/>
+                <constraint firstAttribute="bottom" secondItem="kt7-TL-hNl" secondAttribute="bottom" constant="16" id="5xs-Qv-XzP"/>
+                <constraint firstAttribute="trailing" secondItem="kt7-TL-hNl" secondAttribute="trailing" constant="16" id="7cd-EB-uId"/>
+                <constraint firstAttribute="bottom" secondItem="AsX-pi-UNx" secondAttribute="bottom" constant="16" id="JsL-rU-e7w"/>
+                <constraint firstAttribute="trailing" secondItem="gBo-ia-khY" secondAttribute="trailing" constant="16" id="MF0-O3-sS0"/>
                 <constraint firstItem="wbn-me-TEU" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="gOD-29-p1L"/>
                 <constraint firstItem="kt7-TL-hNl" firstAttribute="leading" secondItem="AsX-pi-UNx" secondAttribute="trailing" constant="8" id="gfM-UI-r0C"/>
-                <constraint firstItem="L9r-Qn-qYV" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="iAT-c5-h1L"/>
-                <constraint firstItem="gBo-ia-khY" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="16" id="kOX-bw-eWt"/>
+                <constraint firstItem="L9r-Qn-qYV" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="iAT-c5-h1L"/>
+                <constraint firstItem="gBo-ia-khY" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="60" id="kOX-bw-eWt"/>
                 <constraint firstAttribute="trailing" secondItem="wbn-me-TEU" secondAttribute="trailing" constant="16" id="ohs-Wj-y4n"/>
                 <constraint firstItem="wbn-me-TEU" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="rQ5-oF-GaH"/>
-                <constraint firstItem="gBo-ia-khY" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="sJG-2u-6ui"/>
+                <constraint firstItem="gBo-ia-khY" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="sJG-2u-6ui"/>
                 <constraint firstItem="L9r-Qn-qYV" firstAttribute="top" secondItem="gBo-ia-khY" secondAttribute="bottom" constant="8" id="wYo-sY-Mbj"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="31.884057971014496" y="-60.602678571428569"/>
+            <point key="canvasLocation" x="1" y="-61"/>
         </view>
     </objects>
     <resources>

--- a/iOS/TodoList/EditCardView.xib
+++ b/iOS/TodoList/EditCardView.xib
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="EditCardView" customModule="TodoList" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="400" height="175"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wbn-me-TEU">
+                    <rect key="frame" x="16" y="16" width="368" height="23"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="23" id="9rO-uA-gKY"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="제목을 입력하세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gBo-ia-khY">
+                    <rect key="frame" x="16" y="60" width="368" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="20" id="wKh-xI-NYj"/>
+                    </constraints>
+                    <color key="textColor" systemColor="systemGray3Color"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="내용을 입력하세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L9r-Qn-qYV">
+                    <rect key="frame" x="16" y="88" width="368" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="xlS-pv-DBo"/>
+                    </constraints>
+                    <color key="textColor" systemColor="systemGray3Color"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AsX-pi-UNx">
+                    <rect key="frame" x="160" y="119" width="108" height="40"/>
+                    <color key="backgroundColor" red="0.8784313725490196" green="0.8784313725490196" blue="0.8784313725490196" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="108" id="j9Z-dd-1qS"/>
+                        <constraint firstAttribute="height" constant="40" id="l5U-mo-wA1"/>
+                    </constraints>
+                    <color key="tintColor" systemColor="systemGray3Color"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" cornerStyle="small">
+                        <attributedString key="attributedTitle">
+                            <fragment content="취소">
+                                <attributes>
+                                    <color key="NSColor" red="0.50980392156862742" green="0.50980392156862742" blue="0.50980392156862742" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <font key="NSFont" size="14" name=".AppleSDGothicNeoI-Bold"/>
+                                    <font key="NSOriginalFont" size="14" name="Helvetica-Bold"/>
+                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                </attributes>
+                            </fragment>
+                        </attributedString>
+                    </buttonConfiguration>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kt7-TL-hNl">
+                    <rect key="frame" x="276" y="119" width="108" height="40"/>
+                    <color key="backgroundColor" red="0.0" green="0.45882352941176469" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="40" id="WI5-rK-cFq"/>
+                        <constraint firstAttribute="width" constant="108" id="v71-Bh-N0v"/>
+                    </constraints>
+                    <color key="tintColor" systemColor="systemBackgroundColor"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" cornerStyle="small">
+                        <attributedString key="attributedTitle">
+                            <fragment content="Button">
+                                <attributes>
+                                    <font key="NSFont" size="14" name="Helvetica-Bold"/>
+                                </attributes>
+                            </fragment>
+                        </attributedString>
+                    </buttonConfiguration>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="L9r-Qn-qYV" secondAttribute="trailing" constant="16" id="1us-dh-jHc"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="kt7-TL-hNl" secondAttribute="bottom" constant="16" id="5xs-Qv-XzP"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="kt7-TL-hNl" secondAttribute="trailing" constant="16" id="7cd-EB-uId"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="AsX-pi-UNx" secondAttribute="bottom" constant="16" id="JsL-rU-e7w"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="gBo-ia-khY" secondAttribute="trailing" constant="16" id="MF0-O3-sS0"/>
+                <constraint firstItem="wbn-me-TEU" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="gOD-29-p1L"/>
+                <constraint firstItem="kt7-TL-hNl" firstAttribute="leading" secondItem="AsX-pi-UNx" secondAttribute="trailing" constant="8" id="gfM-UI-r0C"/>
+                <constraint firstItem="L9r-Qn-qYV" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="iAT-c5-h1L"/>
+                <constraint firstItem="gBo-ia-khY" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="16" id="kOX-bw-eWt"/>
+                <constraint firstAttribute="trailing" secondItem="wbn-me-TEU" secondAttribute="trailing" constant="16" id="ohs-Wj-y4n"/>
+                <constraint firstItem="wbn-me-TEU" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="rQ5-oF-GaH"/>
+                <constraint firstItem="gBo-ia-khY" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="sJG-2u-6ui"/>
+                <constraint firstItem="L9r-Qn-qYV" firstAttribute="top" secondItem="gBo-ia-khY" secondAttribute="bottom" constant="8" id="wYo-sY-Mbj"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="31.884057971014496" y="-60.602678571428569"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray3Color">
+            <color red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOS/TodoList/EditCardViewController.swift
+++ b/iOS/TodoList/EditCardViewController.swift
@@ -1,0 +1,21 @@
+//
+//  EditCardViewController.swift
+//  TodoList
+//
+//  Created by dale on 2022/04/06.
+//
+
+import UIKit
+
+class EditCardViewController: UIViewController {
+    @IBOutlet weak var centerView: UIView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        guard let editCardView = Bundle.main.loadNibNamed("EditCardView", owner: nil, options: nil)?.first as? EditCardView else {return}
+        self.centerView.addSubview(editCardView)
+    }
+
+
+
+}

--- a/iOS/TodoList/Info.plist
+++ b/iOS/TodoList/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/iOS/TodoList/SceneDelegate.swift
+++ b/iOS/TodoList/SceneDelegate.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {}
+
+    func sceneDidBecomeActive(_ scene: UIScene) {}
+
+    func sceneWillResignActive(_ scene: UIScene) {}
+
+    func sceneWillEnterForeground(_ scene: UIScene) {}
+
+    func sceneDidEnterBackground(_ scene: UIScene) {}
+
+}
+

--- a/iOS/TodoList/TaskCardViewCell.swift
+++ b/iOS/TodoList/TaskCardViewCell.swift
@@ -22,6 +22,5 @@ class TaskCardViewCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
     }
 }

--- a/iOS/TodoList/TaskCardViewCell.swift
+++ b/iOS/TodoList/TaskCardViewCell.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+class TaskCardViewCell: UITableViewCell {
+    
+    @IBOutlet weak var cardTitle: UILabel!
+    @IBOutlet weak var cardContents: UILabel!
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        layoutSubviews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        layoutSubviews()
+    }
+    
+    func setColor(to color: UIColor) {
+        self.backgroundColor = color
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
+    }
+}

--- a/iOS/TodoList/TaskCardViewCell.swift
+++ b/iOS/TodoList/TaskCardViewCell.swift
@@ -7,20 +7,14 @@ class TaskCardViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        layoutSubviews()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        layoutSubviews()
     }
     
     func setColor(to color: UIColor) {
         self.backgroundColor = color
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-    }
 }

--- a/iOS/TodoList/TaskCardViewCell.xib
+++ b/iOS/TodoList/TaskCardViewCell.xib
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="cardCell" rowHeight="136" id="KGk-i7-Jjw" customClass="TaskCardViewCell" customModule="TodoList" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="436" height="136"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="436" height="136"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dha-11-yfD">
+                        <rect key="frame" x="0.0" y="0.0" width="436" height="136"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Kn-E6-Ytx">
+                                <rect key="frame" x="16" y="16" width="404" height="23"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="23" id="csd-TS-Lub"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="author by iOS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eeb-LQ-RnX">
+                                <rect key="frame" x="16" y="103" width="404" height="17"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="17" id="oZ4-Gk-wkS"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" red="0.74117647058823533" green="0.74117647058823533" blue="0.74117647058823533" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2EQ-cA-m9k">
+                                <rect key="frame" x="16" y="47" width="404" height="48"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="bt5-sy-hii"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="eeb-LQ-RnX" secondAttribute="trailing" constant="16" id="2cy-6M-mMu"/>
+                            <constraint firstItem="0Kn-E6-Ytx" firstAttribute="top" secondItem="Dha-11-yfD" secondAttribute="top" constant="16" id="7xs-RY-mSs"/>
+                            <constraint firstAttribute="bottom" secondItem="eeb-LQ-RnX" secondAttribute="bottom" constant="16" id="Fxz-kn-mA2"/>
+                            <constraint firstItem="2EQ-cA-m9k" firstAttribute="leading" secondItem="Dha-11-yfD" secondAttribute="leading" constant="16" id="OZE-HC-p8T"/>
+                            <constraint firstItem="eeb-LQ-RnX" firstAttribute="leading" secondItem="Dha-11-yfD" secondAttribute="leading" constant="16" id="bNr-qr-Pvb"/>
+                            <constraint firstItem="2EQ-cA-m9k" firstAttribute="top" secondItem="0Kn-E6-Ytx" secondAttribute="bottom" constant="8" id="eFm-HD-avY"/>
+                            <constraint firstAttribute="trailing" secondItem="0Kn-E6-Ytx" secondAttribute="trailing" constant="16" id="hQM-nk-2tr"/>
+                            <constraint firstItem="eeb-LQ-RnX" firstAttribute="top" secondItem="2EQ-cA-m9k" secondAttribute="bottom" constant="8" id="i1x-8E-P07"/>
+                            <constraint firstItem="0Kn-E6-Ytx" firstAttribute="leading" secondItem="Dha-11-yfD" secondAttribute="leading" constant="16" id="iSC-3S-fOd"/>
+                            <constraint firstAttribute="trailing" secondItem="2EQ-cA-m9k" secondAttribute="trailing" constant="16" id="u4z-ro-w2Y"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                <constraints>
+                    <constraint firstItem="Dha-11-yfD" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="9Cq-F2-lj3"/>
+                    <constraint firstItem="Dha-11-yfD" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="DTY-Fp-dgk"/>
+                    <constraint firstAttribute="bottom" secondItem="Dha-11-yfD" secondAttribute="bottom" id="lYs-6c-TvN"/>
+                    <constraint firstAttribute="trailing" secondItem="Dha-11-yfD" secondAttribute="trailing" id="vr5-dE-sXk"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="cardContents" destination="2EQ-cA-m9k" id="sGC-lN-fqb"/>
+                <outlet property="cardTitle" destination="0Kn-E6-Ytx" id="Abw-Li-Z4i"/>
+            </connections>
+            <point key="canvasLocation" x="221.73913043478262" y="147.99107142857142"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/iOS/TodoList/TaskCardViewCell.xib
+++ b/iOS/TodoList/TaskCardViewCell.xib
@@ -17,7 +17,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dha-11-yfD">
-                        <rect key="frame" x="0.0" y="0.0" width="436" height="136"/>
+                        <rect key="frame" x="0.0" y="0.0" width="436" height="120"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Kn-E6-Ytx">
                                 <rect key="frame" x="16" y="16" width="404" height="23"/>
@@ -29,7 +29,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="author by iOS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eeb-LQ-RnX">
-                                <rect key="frame" x="16" y="103" width="404" height="17"/>
+                                <rect key="frame" x="16" y="87" width="404" height="17"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="17" id="oZ4-Gk-wkS"/>
                                 </constraints>
@@ -38,7 +38,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2EQ-cA-m9k">
-                                <rect key="frame" x="16" y="47" width="404" height="48"/>
+                                <rect key="frame" x="16" y="47" width="404" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="bt5-sy-hii"/>
                                 </constraints>
@@ -60,13 +60,19 @@
                             <constraint firstItem="0Kn-E6-Ytx" firstAttribute="leading" secondItem="Dha-11-yfD" secondAttribute="leading" constant="16" id="iSC-3S-fOd"/>
                             <constraint firstAttribute="trailing" secondItem="2EQ-cA-m9k" secondAttribute="trailing" constant="16" id="u4z-ro-w2Y"/>
                         </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                <integer key="value" value="10"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <constraints>
                     <constraint firstItem="Dha-11-yfD" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="9Cq-F2-lj3"/>
                     <constraint firstItem="Dha-11-yfD" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="DTY-Fp-dgk"/>
-                    <constraint firstAttribute="bottom" secondItem="Dha-11-yfD" secondAttribute="bottom" id="lYs-6c-TvN"/>
+                    <constraint firstAttribute="bottom" secondItem="Dha-11-yfD" secondAttribute="bottom" constant="16" id="lYs-6c-TvN"/>
                     <constraint firstAttribute="trailing" secondItem="Dha-11-yfD" secondAttribute="trailing" id="vr5-dE-sXk"/>
                 </constraints>
             </tableViewCellContentView>

--- a/iOS/TodoList/TaskCardViewCell.xib
+++ b/iOS/TodoList/TaskCardViewCell.xib
@@ -37,7 +37,7 @@
                                 <color key="textColor" red="0.74117647058823533" green="0.74117647058823533" blue="0.74117647058823533" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2EQ-cA-m9k">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2EQ-cA-m9k">
                                 <rect key="frame" x="16" y="47" width="404" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="bt5-sy-hii"/>

--- a/iOS/TodoList/TaskListBoardViewController.swift
+++ b/iOS/TodoList/TaskListBoardViewController.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+class TaskListBoardViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUpStackView()
+                
+    }
+    
+    func setUpStackView() {
+        var taskViewList: [TaskListView] = []
+        
+        for _ in 0...2 {
+            let taskListView = TaskListView(frame: CGRect())
+            taskViewList.append(taskListView)
+        }
+        
+        let stackView = UIStackView(arrangedSubviews: taskViewList)
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = 10
+        
+        view.addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 10),
+            stackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+            stackView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+            stackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: 10)
+        ])
+
+    }
+
+
+}

--- a/iOS/TodoList/TaskListBoardViewController.swift
+++ b/iOS/TodoList/TaskListBoardViewController.swift
@@ -16,10 +16,10 @@ class TaskListBoardViewController: UIViewController {
             self.view.addSubview(taskListView)
             taskListView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                taskListView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 10),
-                taskListView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
-                taskListView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
-                taskListView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -10)
+                taskListView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 0),
+                taskListView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 0),
+                taskListView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: 0),
+                taskListView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: 0)
             ])
         }
     }

--- a/iOS/TodoList/TaskListBoardViewController.swift
+++ b/iOS/TodoList/TaskListBoardViewController.swift
@@ -4,16 +4,14 @@ class TaskListBoardViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         setUpStackView()
-                
     }
     
     func setUpStackView() {
         var taskViewList: [TaskListView] = []
         
         for _ in 0...2 {
-            let taskListView = TaskListView(frame: CGRect())
+            let taskListView: TaskListView = TaskListView()
             taskViewList.append(taskListView)
         }
         
@@ -23,11 +21,12 @@ class TaskListBoardViewController: UIViewController {
         
         stackView.axis = .horizontal
         stackView.alignment = .fill
-        stackView.distribution = .fill
-        stackView.spacing = 10
+        stackView.distribution = .fillEqually
+        stackView.spacing = 22
+        
         
         view.addSubview(stackView)
-        
+
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 10),
             stackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 10),

--- a/iOS/TodoList/TaskListBoardViewController.swift
+++ b/iOS/TodoList/TaskListBoardViewController.swift
@@ -21,7 +21,6 @@ class TaskListBoardViewController: UIViewController {
                 taskListView.frame = self.view.bounds
                 taskViewList.append(taskListView)
             }
-            
         }
         
         let stackView = UIStackView(arrangedSubviews: taskViewList)

--- a/iOS/TodoList/TaskListBoardViewController.swift
+++ b/iOS/TodoList/TaskListBoardViewController.swift
@@ -1,18 +1,27 @@
 import UIKit
 
 class TaskListBoardViewController: UIViewController {
-    
+    var foo: [UIColor] = [.red,.gray,.green,.brown]
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpStackView()
     }
-    
+
     func setUpStackView() {
         var taskViewList: [TaskListView] = []
         
         for _ in 0...2 {
-            let taskListView: TaskListView = TaskListView()
-            taskViewList.append(taskListView)
+            if let taskListView = Bundle.main.loadNibNamed("TaskListView", owner: nil, options: nil)?.first as? TaskListView {
+                taskListView.tableView.delegate = self
+                taskListView.tableView.dataSource = self
+                taskListView.tableView.rowHeight = UITableView.automaticDimension
+                taskListView.tableView.estimatedRowHeight = 400
+                let nibName = UINib(nibName: "TaskCardViewCell", bundle: nil)
+                taskListView.tableView.register(nibName, forCellReuseIdentifier: "cardCell")
+                taskListView.frame = self.view.bounds
+                taskViewList.append(taskListView)
+            }
+            
         }
         
         let stackView = UIStackView(arrangedSubviews: taskViewList)
@@ -31,10 +40,24 @@ class TaskListBoardViewController: UIViewController {
             stackView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 10),
             stackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
             stackView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
-            stackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: 10)
+            stackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -10)
         ])
 
     }
 
 
+}
+
+
+extension TaskListBoardViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.foo.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cardCell", for: indexPath) as! TaskCardViewCell
+        return cell
+    }
+    
 }

--- a/iOS/TodoList/TaskListBoardViewController.swift
+++ b/iOS/TodoList/TaskListBoardViewController.swift
@@ -6,46 +6,31 @@ class TaskListBoardViewController: UIViewController {
         super.viewDidLoad()
         setUpStackView()
     }
-
+    
     func setUpStackView() {
-        var taskViewList: [TaskListView] = []
-        
-        for _ in 0...2 {
-            if let taskListView = Bundle.main.loadNibNamed("TaskListView", owner: nil, options: nil)?.first as? TaskListView {
-                taskListView.tableView.delegate = self
-                taskListView.tableView.dataSource = self
-                taskListView.tableView.rowHeight = UITableView.automaticDimension
-                taskListView.tableView.estimatedRowHeight = 400
-                let nibName = UINib(nibName: "TaskCardViewCell", bundle: nil)
-                taskListView.tableView.register(nibName, forCellReuseIdentifier: "cardCell")
-                taskListView.frame = self.view.bounds
-                taskViewList.append(taskListView)
-            }
+        if let taskListView = Bundle.main.loadNibNamed("TaskListView", owner: nil, options: nil)?.first as? TaskListView {
+            taskListView.tableView.delegate = self
+            taskListView.tableView.dataSource = self
+            let nibName = UINib(nibName: "TaskCardViewCell", bundle: nil)
+            taskListView.tableView.register(nibName, forCellReuseIdentifier: "cardCell")
+            self.view.addSubview(taskListView)
+            taskListView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                taskListView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 10),
+                taskListView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+                taskListView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+                taskListView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -10)
+            ])
         }
-        
-        let stackView = UIStackView(arrangedSubviews: taskViewList)
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        stackView.axis = .horizontal
-        stackView.alignment = .fill
-        stackView.distribution = .fillEqually
-        stackView.spacing = 22
-        
-        
-        view.addSubview(stackView)
-
-        NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 10),
-            stackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
-            stackView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
-            stackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -10)
-        ])
-
     }
-
-
+    
+    func add() {
+        self.foo.append(UIColor.brown)
+    }
 }
+           
+
+
 
 
 extension TaskListBoardViewController: UITableViewDelegate, UITableViewDataSource {

--- a/iOS/TodoList/TaskListCell.swift
+++ b/iOS/TodoList/TaskListCell.swift
@@ -1,0 +1,23 @@
+//
+//  TaskListCell.swift
+//  TodoList
+//
+//  Created by dale on 2022/04/05.
+//
+
+import UIKit
+
+class TaskListCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+}

--- a/iOS/TodoList/TaskListCell.xib
+++ b/iOS/TodoList/TaskListCell.xib
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="TaskListCell" customModule="TodoList" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="139" y="83"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/iOS/TodoList/TaskListView.swift
+++ b/iOS/TodoList/TaskListView.swift
@@ -5,9 +5,16 @@ class TaskListView: UIView {
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var taskCountBadge: UILabel!
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
+        let className = String(describing: type(of: self))
+        let nib = UINib(nibName: className, bundle: Bundle.main)
+        
+        guard let xibView = nib.instantiate(withOwner: self, options: nil).first as? UIView else { return }
+        xibView.frame = self.bounds
+        xibView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.addSubview(xibView)
     }
     
     required init?(coder: NSCoder) {

--- a/iOS/TodoList/TaskListView.swift
+++ b/iOS/TodoList/TaskListView.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class TaskListView: UIView {
+    
+    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var taskCountBadge: UILabel!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    @IBAction func addTaskButtonTouched(_ sender: UIButton) {
+    }
+}

--- a/iOS/TodoList/TaskListView.swift
+++ b/iOS/TodoList/TaskListView.swift
@@ -1,20 +1,12 @@
 import UIKit
 
 class TaskListView: UIView {
-    
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var taskCountBadge: UILabel!
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        let className = String(describing: type(of: self))
-        let nib = UINib(nibName: className, bundle: Bundle.main)
-        
-        guard let xibView = nib.instantiate(withOwner: self, options: nil).first as? UIView else { return }
-        xibView.frame = self.bounds
-        xibView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        self.addSubview(xibView)
     }
     
     required init?(coder: NSCoder) {
@@ -24,3 +16,4 @@ class TaskListView: UIView {
     @IBAction func addTaskButtonTouched(_ sender: UIButton) {
     }
 }
+

--- a/iOS/TodoList/TaskListView.xib
+++ b/iOS/TodoList/TaskListView.xib
@@ -8,14 +8,14 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TaskListView" customModule="TodoList" customModuleProvider="target"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="TaskListView" customModule="TodoList" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="507" height="375"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <rect key="frame" x="0.0" y="0.0" width="495" height="375"/>
+            <autoresizingMask key="autoresizingMask"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0sR-f9-J2x">
-                    <rect key="frame" x="20" y="17" width="322" height="26"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0sR-f9-J2x">
+                    <rect key="frame" x="20" y="17" width="76" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="26" id="Qv5-oj-GPJ"/>
                     </constraints>
@@ -23,8 +23,8 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ez7-ve-Lzi">
-                    <rect key="frame" x="480" y="6" width="14" height="14"/>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ez7-ve-Lzi">
+                    <rect key="frame" x="472" y="21" width="14" height="14"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="13.789999999999999" id="5Jz-g0-xQU"/>
                         <constraint firstAttribute="width" secondItem="ez7-ve-Lzi" secondAttribute="height" multiplier="1:1" id="iDY-jm-bwa"/>
@@ -35,37 +35,41 @@
                         <action selector="addTaskButtonTouched:" destination="iN0-l3-epB" eventType="touchUpInside" id="Zhg-xw-ILN"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBY-PI-YWR">
-                    <rect key="frame" x="350" y="0.0" width="26" height="26"/>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="oul-8H-180">
+                    <rect key="frame" x="0.0" y="44" width="495" height="297"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="12" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBY-PI-YWR">
+                    <rect key="frame" x="88" y="17" width="59" height="26"/>
                     <color key="backgroundColor" red="0.74117647058823533" green="0.74117647058823533" blue="0.74117647058823533" alpha="1" colorSpace="calibratedRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="26" id="MbK-6X-dc8"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="26" id="hwV-hP-Lt6"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="13"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
                 </label>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="oul-8H-180">
-                    <rect key="frame" x="0.0" y="44" width="507" height="297"/>
-                    <color key="backgroundColor" systemColor="systemBrownColor"/>
-                </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" systemColor="systemCyanColor"/>
             <accessibility key="accessibilityConfiguration" identifier="taskList"/>
             <constraints>
                 <constraint firstItem="oul-8H-180" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="GB3-eJ-T5F"/>
                 <constraint firstItem="0sR-f9-J2x" firstAttribute="top" secondItem="oul-8H-180" secondAttribute="top" constant="-27" id="WA4-kW-VPH"/>
-                <constraint firstItem="HBY-PI-YWR" firstAttribute="top" secondItem="oul-8H-180" secondAttribute="top" constant="-44" id="XV8-or-3jV"/>
                 <constraint firstItem="0sR-f9-J2x" firstAttribute="leading" secondItem="oul-8H-180" secondAttribute="leading" constant="20" id="Zro-Bf-ahz"/>
                 <constraint firstItem="HBY-PI-YWR" firstAttribute="leading" secondItem="0sR-f9-J2x" secondAttribute="trailing" constant="8" id="abj-xj-EgP"/>
-                <constraint firstItem="ez7-ve-Lzi" firstAttribute="top" secondItem="oul-8H-180" secondAttribute="top" constant="-38" id="fRY-i2-8cv"/>
                 <constraint firstItem="oul-8H-180" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="hd4-nK-u17"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="oul-8H-180" secondAttribute="trailing" id="lol-xH-Ljn"/>
+                <constraint firstItem="HBY-PI-YWR" firstAttribute="bottom" secondItem="oul-8H-180" secondAttribute="top" id="m9H-hG-sdx"/>
+                <constraint firstItem="ez7-ve-Lzi" firstAttribute="firstBaseline" secondItem="HBY-PI-YWR" secondAttribute="firstBaseline" id="mid-di-Std"/>
                 <constraint firstItem="oul-8H-180" firstAttribute="trailing" secondItem="ez7-ve-Lzi" secondAttribute="trailing" constant="13.109999999999999" id="oAg-E5-CQE"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="oul-8H-180" secondAttribute="bottom" id="pM8-fy-rfk"/>
-                <constraint firstItem="oul-8H-180" firstAttribute="trailing" secondItem="0sR-f9-J2x" secondAttribute="trailing" constant="165" id="tgU-U2-9QQ"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
@@ -77,11 +81,8 @@
         </view>
     </objects>
     <resources>
-        <systemColor name="systemBrownColor">
-            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemCyanColor">
-            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/iOS/TodoList/TaskListView.xib
+++ b/iOS/TodoList/TaskListView.xib
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="TaskListView" customModule="TodoList" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="507" height="375"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0sR-f9-J2x">
+                    <rect key="frame" x="20" y="17" width="322" height="26"/>
+                    <constraints>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="26" id="Qv5-oj-GPJ"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ez7-ve-Lzi">
+                    <rect key="frame" x="480" y="6" width="14" height="14"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="13.789999999999999" id="5Jz-g0-xQU"/>
+                        <constraint firstAttribute="width" secondItem="ez7-ve-Lzi" secondAttribute="height" multiplier="1:1" id="iDY-jm-bwa"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="+"/>
+                    <connections>
+                        <action selector="addTaskButtonTouched:" destination="iN0-l3-epB" eventType="touchUpInside" id="Zhg-xw-ILN"/>
+                    </connections>
+                </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBY-PI-YWR">
+                    <rect key="frame" x="350" y="0.0" width="26" height="26"/>
+                    <color key="backgroundColor" red="0.74117647058823533" green="0.74117647058823533" blue="0.74117647058823533" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="26" id="MbK-6X-dc8"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="26" id="hwV-hP-Lt6"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="oul-8H-180">
+                    <rect key="frame" x="0.0" y="44" width="507" height="297"/>
+                    <color key="backgroundColor" systemColor="systemBrownColor"/>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemCyanColor"/>
+            <accessibility key="accessibilityConfiguration" identifier="taskList"/>
+            <constraints>
+                <constraint firstItem="oul-8H-180" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="GB3-eJ-T5F"/>
+                <constraint firstItem="0sR-f9-J2x" firstAttribute="top" secondItem="oul-8H-180" secondAttribute="top" constant="-27" id="WA4-kW-VPH"/>
+                <constraint firstItem="HBY-PI-YWR" firstAttribute="top" secondItem="oul-8H-180" secondAttribute="top" constant="-44" id="XV8-or-3jV"/>
+                <constraint firstItem="0sR-f9-J2x" firstAttribute="leading" secondItem="oul-8H-180" secondAttribute="leading" constant="20" id="Zro-Bf-ahz"/>
+                <constraint firstItem="HBY-PI-YWR" firstAttribute="leading" secondItem="0sR-f9-J2x" secondAttribute="trailing" constant="8" id="abj-xj-EgP"/>
+                <constraint firstItem="ez7-ve-Lzi" firstAttribute="top" secondItem="oul-8H-180" secondAttribute="top" constant="-38" id="fRY-i2-8cv"/>
+                <constraint firstItem="oul-8H-180" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="hd4-nK-u17"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="oul-8H-180" secondAttribute="trailing" id="lol-xH-Ljn"/>
+                <constraint firstItem="oul-8H-180" firstAttribute="trailing" secondItem="ez7-ve-Lzi" secondAttribute="trailing" constant="13.109999999999999" id="oAg-E5-CQE"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="oul-8H-180" secondAttribute="bottom" id="pM8-fy-rfk"/>
+                <constraint firstItem="oul-8H-180" firstAttribute="trailing" secondItem="0sR-f9-J2x" secondAttribute="trailing" constant="165" id="tgU-U2-9QQ"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="tableView" destination="oul-8H-180" id="5Us-Ho-zeu"/>
+                <outlet property="taskCountBadge" destination="HBY-PI-YWR" id="IfH-ye-Vuf"/>
+                <outlet property="titleLabel" destination="0sR-f9-J2x" id="nvm-NJ-vbs"/>
+            </connections>
+            <point key="canvasLocation" x="319.56521739130437" y="228.01339285714283"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBrownColor">
+            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemCyanColor">
+            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOS/TodoList/TaskListView.xib
+++ b/iOS/TodoList/TaskListView.xib
@@ -13,8 +13,8 @@
             <rect key="frame" x="0.0" y="0.0" width="495" height="375"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0sR-f9-J2x">
-                    <rect key="frame" x="20" y="17" width="76" height="26"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0sR-f9-J2x">
+                    <rect key="frame" x="8" y="2" width="41.5" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="26" id="Qv5-oj-GPJ"/>
                     </constraints>
@@ -23,23 +23,24 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ez7-ve-Lzi">
-                    <rect key="frame" x="472" y="21" width="14" height="14"/>
+                    <rect key="frame" x="472" y="6" width="14" height="14"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="13.789999999999999" id="5Jz-g0-xQU"/>
                         <constraint firstAttribute="width" secondItem="ez7-ve-Lzi" secondAttribute="height" multiplier="1:1" id="iDY-jm-bwa"/>
                     </constraints>
+                    <color key="tintColor" red="0.74117647058823533" green="0.74117647058823533" blue="0.74117647058823533" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" title="Button"/>
-                    <buttonConfiguration key="configuration" style="plain" title="+"/>
+                    <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system"/>
                     <connections>
                         <action selector="addTaskButtonTouched:" destination="iN0-l3-epB" eventType="touchUpInside" id="Zhg-xw-ILN"/>
                     </connections>
                 </button>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="oul-8H-180">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="oul-8H-180">
                     <rect key="frame" x="0.0" y="44" width="495" height="297"/>
                     <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </tableView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="12" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBY-PI-YWR">
-                    <rect key="frame" x="88" y="17" width="59" height="26"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBY-PI-YWR">
+                    <rect key="frame" x="57.5" y="2" width="26" height="26"/>
                     <color key="backgroundColor" red="0.74117647058823533" green="0.74117647058823533" blue="0.74117647058823533" alpha="1" colorSpace="calibratedRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="26" id="MbK-6X-dc8"/>
@@ -59,14 +60,14 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <accessibility key="accessibilityConfiguration" identifier="taskList"/>
             <constraints>
+                <constraint firstItem="oul-8H-180" firstAttribute="top" secondItem="0sR-f9-J2x" secondAttribute="bottom" constant="16" id="3Rd-xM-NnS"/>
+                <constraint firstItem="oul-8H-180" firstAttribute="top" secondItem="HBY-PI-YWR" secondAttribute="bottom" constant="16" id="9zK-fz-0zb"/>
                 <constraint firstItem="oul-8H-180" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="GB3-eJ-T5F"/>
-                <constraint firstItem="0sR-f9-J2x" firstAttribute="top" secondItem="oul-8H-180" secondAttribute="top" constant="-27" id="WA4-kW-VPH"/>
-                <constraint firstItem="0sR-f9-J2x" firstAttribute="leading" secondItem="oul-8H-180" secondAttribute="leading" constant="20" id="Zro-Bf-ahz"/>
+                <constraint firstItem="ez7-ve-Lzi" firstAttribute="centerY" secondItem="HBY-PI-YWR" secondAttribute="centerY" id="J27-7I-i6t"/>
+                <constraint firstItem="0sR-f9-J2x" firstAttribute="leading" secondItem="oul-8H-180" secondAttribute="leading" constant="8" id="Zro-Bf-ahz"/>
                 <constraint firstItem="HBY-PI-YWR" firstAttribute="leading" secondItem="0sR-f9-J2x" secondAttribute="trailing" constant="8" id="abj-xj-EgP"/>
                 <constraint firstItem="oul-8H-180" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="hd4-nK-u17"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="oul-8H-180" secondAttribute="trailing" id="lol-xH-Ljn"/>
-                <constraint firstItem="HBY-PI-YWR" firstAttribute="bottom" secondItem="oul-8H-180" secondAttribute="top" id="m9H-hG-sdx"/>
-                <constraint firstItem="ez7-ve-Lzi" firstAttribute="firstBaseline" secondItem="HBY-PI-YWR" secondAttribute="firstBaseline" id="mid-di-Std"/>
                 <constraint firstItem="oul-8H-180" firstAttribute="trailing" secondItem="ez7-ve-Lzi" secondAttribute="trailing" constant="13.109999999999999" id="oAg-E5-CQE"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="oul-8H-180" secondAttribute="bottom" id="pM8-fy-rfk"/>
             </constraints>
@@ -79,4 +80,7 @@
             <point key="canvasLocation" x="319.56521739130437" y="228.01339285714283"/>
         </view>
     </objects>
+    <resources>
+        <image name="plus" catalog="system" width="128" height="113"/>
+    </resources>
 </document>

--- a/iOS/TodoList/TaskListView.xib
+++ b/iOS/TodoList/TaskListView.xib
@@ -66,7 +66,7 @@
                 <constraint firstItem="ez7-ve-Lzi" firstAttribute="centerY" secondItem="HBY-PI-YWR" secondAttribute="centerY" id="J27-7I-i6t"/>
                 <constraint firstItem="0sR-f9-J2x" firstAttribute="leading" secondItem="oul-8H-180" secondAttribute="leading" constant="8" id="Zro-Bf-ahz"/>
                 <constraint firstItem="HBY-PI-YWR" firstAttribute="leading" secondItem="0sR-f9-J2x" secondAttribute="trailing" constant="8" id="abj-xj-EgP"/>
-                <constraint firstItem="oul-8H-180" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="hd4-nK-u17"/>
+                <constraint firstItem="oul-8H-180" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="hd4-nK-u17"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="oul-8H-180" secondAttribute="trailing" id="lol-xH-Ljn"/>
                 <constraint firstItem="oul-8H-180" firstAttribute="trailing" secondItem="ez7-ve-Lzi" secondAttribute="trailing" constant="13.109999999999999" id="oAg-E5-CQE"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="oul-8H-180" secondAttribute="bottom" id="pM8-fy-rfk"/>

--- a/iOS/TodoList/TaskListView.xib
+++ b/iOS/TodoList/TaskListView.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -35,9 +34,9 @@
                         <action selector="addTaskButtonTouched:" destination="iN0-l3-epB" eventType="touchUpInside" id="Zhg-xw-ILN"/>
                     </connections>
                 </button>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="oul-8H-180">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="oul-8H-180">
                     <rect key="frame" x="0.0" y="44" width="495" height="297"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </tableView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="12" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBY-PI-YWR">
                     <rect key="frame" x="88" y="17" width="59" height="26"/>
@@ -80,9 +79,4 @@
             <point key="canvasLocation" x="319.56521739130437" y="228.01339285714283"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/iOS/TodoList/ViewController.swift
+++ b/iOS/TodoList/ViewController.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+}
+

--- a/iOS/TodoList/ViewController.swift
+++ b/iOS/TodoList/ViewController.swift
@@ -2,6 +2,9 @@ import UIKit
 
 class ViewController: UIViewController {
     @IBOutlet weak var taskListStackView: UIStackView!
+    
+    @IBOutlet weak var stackViewTrailing: NSLayoutConstraint!
+    
     private let todoViewController = TaskListBoardViewController()
     private let doingViewController = TaskListBoardViewController()
     private let doneViewController = TaskListBoardViewController()
@@ -10,7 +13,7 @@ class ViewController: UIViewController {
         addChild(todoViewController)
         addChild(doingViewController)
         addChild(doneViewController)
-        todoViewController.add()
+        
         layout()
     }
     
@@ -26,7 +29,18 @@ class ViewController: UIViewController {
         self.taskListStackView.distribution = .fillEqually
         self.taskListStackView.spacing = 22
     }
-
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        resizeConstant()
+    }
+    
+    private func resizeConstant() {
+        if UIDevice.current.orientation.isPortrait {
+            stackViewTrailing.constant = 48
+        }else {
+            stackViewTrailing.constant = 330
+        }
+    }
 }
 
 

--- a/iOS/TodoList/ViewController.swift
+++ b/iOS/TodoList/ViewController.swift
@@ -1,11 +1,30 @@
 import UIKit
 
 class ViewController: UIViewController {
-    
+    @IBOutlet weak var taskListStackView: UIStackView!
+    private let todoViewController = TaskListBoardViewController()
+    private let doingViewController = TaskListBoardViewController()
+    private let doneViewController = TaskListBoardViewController()
     override func viewDidLoad() {
         super.viewDidLoad()
+        addChild(todoViewController)
+        addChild(doingViewController)
+        addChild(doneViewController)
+        todoViewController.add()
+        layout()
+    }
+    
+    private func layout() {
+        self.taskListStackView.translatesAutoresizingMaskIntoConstraints = false
         
-        
+        self.children.forEach{
+            self.taskListStackView.addArrangedSubview($0.view)
+        }
+                
+        self.taskListStackView.axis = .horizontal
+        self.taskListStackView.alignment = .fill
+        self.taskListStackView.distribution = .fillEqually
+        self.taskListStackView.spacing = 22
     }
 
 }

--- a/iOS/TodoList/ViewController.swift
+++ b/iOS/TodoList/ViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var taskListStackView: UIStackView!
     
+    @IBOutlet weak var actionFlowButton: UIButton!
     @IBOutlet weak var stackViewTrailing: NSLayoutConstraint!
     
     private let todoViewController = TaskListBoardViewController()
@@ -17,6 +18,9 @@ class ViewController: UIViewController {
         layout()
     }
     
+    @IBAction func actionFlowButtonTapped(_ sender: UIButton) {
+        editCardButtonTapped()
+    }
     private func layout() {
         self.taskListStackView.translatesAutoresizingMaskIntoConstraints = false
         
@@ -41,7 +45,20 @@ class ViewController: UIViewController {
             stackViewTrailing.constant = 330
         }
     }
+    
+    private func editCardButtonTapped() {
+        guard let popVC = storyboard?.instantiateViewController(withIdentifier: "popVC") as? EditCardViewController else { return }
+        
+        popVC.modalPresentationStyle = .overFullScreen
+        
+        self.present(popVC, animated: false)
+    }
 }
 
+extension ViewController: UIPopoverPresentationControllerDelegate {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+               return .none
+           }
+}
 
     

--- a/iOS/TodoList/ViewController.swift
+++ b/iOS/TodoList/ViewController.swift
@@ -1,11 +1,14 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        
+        
     }
 
 }
 
+
+    


### PR DESCRIPTION
## 작업 내용

### 리스트 (Table View)
- xib로 재활용 리스트 만들기
  - [x] 제목/배지/추가 버튼, 카드 목록
  - [x] 배지 모서리 없이 표시하고 숫자가 늘어나면 iOS 기본 배지처럼 가운데 영역이 길어진다.

### 리스트 카드
- xib로 재활용 카드 만들기
  - [x] 제목, 본문 (3줄까지)
  - [x] 셀 높이 self-resizing

### 리스트 카드 추가/편집 화면
- xib로 재활용 뷰 만들기
  - [x] 제목, 본문, 취소/등록

## 결과물
- 액션 기록 화면 제외 전체화면 뷰 구현
- 가로 세로 방향에 따라 stackview의 constant를 변경하여 테이블의 셀이 너무 작아지지 않도록 함
- 리스트 추가 카드는 임시로 메뉴 버튼 누르면 뜨도록 구현

<img width="640" src="https://user-images.githubusercontent.com/78553659/161928635-a1c003c4-e000-4c42-b75b-02975607d13c.gif">

## 고민
- 이번 구현에서는 전체적인 구조보다는 뷰를 구현하는 것을 목표로 작업하였습니다. 아직 구조는 신경쓰지 않고 작업을 진행해서, 구조보다는 뷰 위주로 리뷰해주셨으면 좋겠습니다. 
- xib를 만들 때, UIView를 만들고 TableViewCell등을 넣을 지, 바로 TableViewCell로 만들지 등에 대해서도 고민했습니다. 
- xib를 만들 때, UIViewController로 만들어야하는지에 대해서도 고민했습니다.
- 하나의 viewController가 어느 정도 범위의 뷰까지를 컨트롤 해야할지에 대해서도 고민했습니다. (구조 부분 개선할 때 더 생각해볼 예정이긴 합니다...ㅎ....)
- 테이블 뷰 컨트롤러를 최대한 재활용하고 싶어서, 메인 뷰 컨트롤러에서 스택뷰 하나를 만든 후 3개의 뷰를 넣는 방식으로 구현했는데, 컨테이너 뷰3개를 따로 만들어서 그쪽에서 테이블 뷰 컨트롤러를 생성했어야 하는지 고민입니다. 

뷰에 대해 정답은 없다고 생각하지만, 최대한 구조적으로 안정적인 방식에 대해 궁금합니다!


