### PR TITLE
[iOS][team10] 메인 뷰의 카드 리스트 테이블 뷰 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,288 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos,java,intellij,gradle,swift,xcode
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,java,intellij,gradle,swift,xcode
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Xcode ###
+
+## Xcode 8 and earlier
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,java,intellij,gradle,swift,xcode

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# todo-list
-그룹 프로젝트 #1
+# Todo-Team10
+## Member
+🔙 Backend : [반스](https://github.com/ffinn92), [로니](https://github.com/CMSSKKK) </br>
+🍎 ios : [Ocean](https://github.com/OceanShape), [Sol](https://github.com/Hansolkkim)
+
+## Rule
+[Ground Rules](https://github.com/OceanShape/todo-list/wiki/Ground-Rules)

--- a/ToDoList/ToDoList.xcodeproj/project.pbxproj
+++ b/ToDoList/ToDoList.xcodeproj/project.pbxproj
@@ -1,0 +1,609 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		02DF5F9727FD6EFF0064FEC8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5F9627FD6EFF0064FEC8 /* AppDelegate.swift */; };
+		02DF5F9927FD6EFF0064FEC8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5F9827FD6EFF0064FEC8 /* SceneDelegate.swift */; };
+		02DF5F9B27FD6EFF0064FEC8 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5F9A27FD6EFF0064FEC8 /* ViewController.swift */; };
+		02DF5F9E27FD6EFF0064FEC8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 02DF5F9C27FD6EFF0064FEC8 /* Main.storyboard */; };
+		02DF5FA027FD6F020064FEC8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 02DF5F9F27FD6F020064FEC8 /* Assets.xcassets */; };
+		02DF5FA327FD6F020064FEC8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 02DF5FA127FD6F020064FEC8 /* LaunchScreen.storyboard */; };
+		02DF5FAE27FD6F020064FEC8 /* ToDoListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FAD27FD6F020064FEC8 /* ToDoListTests.swift */; };
+		02DF5FB827FD6F020064FEC8 /* ToDoListUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FB727FD6F020064FEC8 /* ToDoListUITests.swift */; };
+		02DF5FBA27FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FB927FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		02DF5FAA27FD6F020064FEC8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 02DF5F8B27FD6EFF0064FEC8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 02DF5F9227FD6EFF0064FEC8;
+			remoteInfo = ToDoList;
+		};
+		02DF5FB427FD6F020064FEC8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 02DF5F8B27FD6EFF0064FEC8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 02DF5F9227FD6EFF0064FEC8;
+			remoteInfo = ToDoList;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		02DF5F9327FD6EFF0064FEC8 /* ToDoList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDoList.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		02DF5F9627FD6EFF0064FEC8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		02DF5F9827FD6EFF0064FEC8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		02DF5F9A27FD6EFF0064FEC8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		02DF5F9D27FD6EFF0064FEC8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		02DF5F9F27FD6F020064FEC8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		02DF5FA227FD6F020064FEC8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		02DF5FA427FD6F020064FEC8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		02DF5FA927FD6F020064FEC8 /* ToDoListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToDoListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		02DF5FAD27FD6F020064FEC8 /* ToDoListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListTests.swift; sourceTree = "<group>"; };
+		02DF5FB327FD6F020064FEC8 /* ToDoListUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToDoListUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		02DF5FB727FD6F020064FEC8 /* ToDoListUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListUITests.swift; sourceTree = "<group>"; };
+		02DF5FB927FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		02DF5F9027FD6EFF0064FEC8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02DF5FA627FD6F020064FEC8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02DF5FB027FD6F020064FEC8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		02DF5F8A27FD6EFF0064FEC8 = {
+			isa = PBXGroup;
+			children = (
+				02DF5F9527FD6EFF0064FEC8 /* ToDoList */,
+				02DF5FAC27FD6F020064FEC8 /* ToDoListTests */,
+				02DF5FB627FD6F020064FEC8 /* ToDoListUITests */,
+				02DF5F9427FD6EFF0064FEC8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		02DF5F9427FD6EFF0064FEC8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				02DF5F9327FD6EFF0064FEC8 /* ToDoList.app */,
+				02DF5FA927FD6F020064FEC8 /* ToDoListTests.xctest */,
+				02DF5FB327FD6F020064FEC8 /* ToDoListUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		02DF5F9527FD6EFF0064FEC8 /* ToDoList */ = {
+			isa = PBXGroup;
+			children = (
+				02DF5F9627FD6EFF0064FEC8 /* AppDelegate.swift */,
+				02DF5F9827FD6EFF0064FEC8 /* SceneDelegate.swift */,
+				02DF5F9A27FD6EFF0064FEC8 /* ViewController.swift */,
+				02DF5F9C27FD6EFF0064FEC8 /* Main.storyboard */,
+				02DF5F9F27FD6F020064FEC8 /* Assets.xcassets */,
+				02DF5FA127FD6F020064FEC8 /* LaunchScreen.storyboard */,
+				02DF5FA427FD6F020064FEC8 /* Info.plist */,
+			);
+			path = ToDoList;
+			sourceTree = "<group>";
+		};
+		02DF5FAC27FD6F020064FEC8 /* ToDoListTests */ = {
+			isa = PBXGroup;
+			children = (
+				02DF5FAD27FD6F020064FEC8 /* ToDoListTests.swift */,
+			);
+			path = ToDoListTests;
+			sourceTree = "<group>";
+		};
+		02DF5FB627FD6F020064FEC8 /* ToDoListUITests */ = {
+			isa = PBXGroup;
+			children = (
+				02DF5FB727FD6F020064FEC8 /* ToDoListUITests.swift */,
+				02DF5FB927FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift */,
+			);
+			path = ToDoListUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		02DF5F9227FD6EFF0064FEC8 /* ToDoList */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 02DF5FBD27FD6F020064FEC8 /* Build configuration list for PBXNativeTarget "ToDoList" */;
+			buildPhases = (
+				02DF5F8F27FD6EFF0064FEC8 /* Sources */,
+				02DF5F9027FD6EFF0064FEC8 /* Frameworks */,
+				02DF5F9127FD6EFF0064FEC8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ToDoList;
+			productName = ToDoList;
+			productReference = 02DF5F9327FD6EFF0064FEC8 /* ToDoList.app */;
+			productType = "com.apple.product-type.application";
+		};
+		02DF5FA827FD6F020064FEC8 /* ToDoListTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 02DF5FC027FD6F020064FEC8 /* Build configuration list for PBXNativeTarget "ToDoListTests" */;
+			buildPhases = (
+				02DF5FA527FD6F020064FEC8 /* Sources */,
+				02DF5FA627FD6F020064FEC8 /* Frameworks */,
+				02DF5FA727FD6F020064FEC8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				02DF5FAB27FD6F020064FEC8 /* PBXTargetDependency */,
+			);
+			name = ToDoListTests;
+			productName = ToDoListTests;
+			productReference = 02DF5FA927FD6F020064FEC8 /* ToDoListTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		02DF5FB227FD6F020064FEC8 /* ToDoListUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 02DF5FC327FD6F020064FEC8 /* Build configuration list for PBXNativeTarget "ToDoListUITests" */;
+			buildPhases = (
+				02DF5FAF27FD6F020064FEC8 /* Sources */,
+				02DF5FB027FD6F020064FEC8 /* Frameworks */,
+				02DF5FB127FD6F020064FEC8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				02DF5FB527FD6F020064FEC8 /* PBXTargetDependency */,
+			);
+			name = ToDoListUITests;
+			productName = ToDoListUITests;
+			productReference = 02DF5FB327FD6F020064FEC8 /* ToDoListUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		02DF5F8B27FD6EFF0064FEC8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					02DF5F9227FD6EFF0064FEC8 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					02DF5FA827FD6F020064FEC8 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = 02DF5F9227FD6EFF0064FEC8;
+					};
+					02DF5FB227FD6F020064FEC8 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = 02DF5F9227FD6EFF0064FEC8;
+					};
+				};
+			};
+			buildConfigurationList = 02DF5F8E27FD6EFF0064FEC8 /* Build configuration list for PBXProject "ToDoList" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 02DF5F8A27FD6EFF0064FEC8;
+			productRefGroup = 02DF5F9427FD6EFF0064FEC8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				02DF5F9227FD6EFF0064FEC8 /* ToDoList */,
+				02DF5FA827FD6F020064FEC8 /* ToDoListTests */,
+				02DF5FB227FD6F020064FEC8 /* ToDoListUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		02DF5F9127FD6EFF0064FEC8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				02DF5FA327FD6F020064FEC8 /* LaunchScreen.storyboard in Resources */,
+				02DF5FA027FD6F020064FEC8 /* Assets.xcassets in Resources */,
+				02DF5F9E27FD6EFF0064FEC8 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02DF5FA727FD6F020064FEC8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02DF5FB127FD6F020064FEC8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		02DF5F8F27FD6EFF0064FEC8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				02DF5F9B27FD6EFF0064FEC8 /* ViewController.swift in Sources */,
+				02DF5F9727FD6EFF0064FEC8 /* AppDelegate.swift in Sources */,
+				02DF5F9927FD6EFF0064FEC8 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02DF5FA527FD6F020064FEC8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				02DF5FAE27FD6F020064FEC8 /* ToDoListTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02DF5FAF27FD6F020064FEC8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				02DF5FBA27FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift in Sources */,
+				02DF5FB827FD6F020064FEC8 /* ToDoListUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		02DF5FAB27FD6F020064FEC8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 02DF5F9227FD6EFF0064FEC8 /* ToDoList */;
+			targetProxy = 02DF5FAA27FD6F020064FEC8 /* PBXContainerItemProxy */;
+		};
+		02DF5FB527FD6F020064FEC8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 02DF5F9227FD6EFF0064FEC8 /* ToDoList */;
+			targetProxy = 02DF5FB427FD6F020064FEC8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		02DF5F9C27FD6EFF0064FEC8 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				02DF5F9D27FD6EFF0064FEC8 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		02DF5FA127FD6F020064FEC8 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				02DF5FA227FD6F020064FEC8 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		02DF5FBB27FD6F020064FEC8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		02DF5FBC27FD6F020064FEC8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		02DF5FBE27FD6F020064FEC8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9HYJMYU99M;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ToDoList/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.ToDoList;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 2;
+			};
+			name = Debug;
+		};
+		02DF5FBF27FD6F020064FEC8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9HYJMYU99M;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ToDoList/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.ToDoList;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 2;
+			};
+			name = Release;
+		};
+		02DF5FC127FD6F020064FEC8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9HYJMYU99M;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.ToDoListTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ToDoList.app/ToDoList";
+			};
+			name = Debug;
+		};
+		02DF5FC227FD6F020064FEC8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9HYJMYU99M;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.ToDoListTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ToDoList.app/ToDoList";
+			};
+			name = Release;
+		};
+		02DF5FC427FD6F020064FEC8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9HYJMYU99M;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.ToDoListUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ToDoList;
+			};
+			name = Debug;
+		};
+		02DF5FC527FD6F020064FEC8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9HYJMYU99M;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.ToDoListUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ToDoList;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		02DF5F8E27FD6EFF0064FEC8 /* Build configuration list for PBXProject "ToDoList" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02DF5FBB27FD6F020064FEC8 /* Debug */,
+				02DF5FBC27FD6F020064FEC8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		02DF5FBD27FD6F020064FEC8 /* Build configuration list for PBXNativeTarget "ToDoList" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02DF5FBE27FD6F020064FEC8 /* Debug */,
+				02DF5FBF27FD6F020064FEC8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		02DF5FC027FD6F020064FEC8 /* Build configuration list for PBXNativeTarget "ToDoListTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02DF5FC127FD6F020064FEC8 /* Debug */,
+				02DF5FC227FD6F020064FEC8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		02DF5FC327FD6F020064FEC8 /* Build configuration list for PBXNativeTarget "ToDoListUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02DF5FC427FD6F020064FEC8 /* Debug */,
+				02DF5FC527FD6F020064FEC8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 02DF5F8B27FD6EFF0064FEC8 /* Project object */;
+}

--- a/ToDoList/ToDoList.xcodeproj/project.pbxproj
+++ b/ToDoList/ToDoList.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		02DF5FAE27FD6F020064FEC8 /* ToDoListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FAD27FD6F020064FEC8 /* ToDoListTests.swift */; };
 		02DF5FB827FD6F020064FEC8 /* ToDoListUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FB727FD6F020064FEC8 /* ToDoListUITests.swift */; };
 		02DF5FBA27FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FB927FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift */; };
+		F5164AB027FD7A0F00C32212 /* CardListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5164AAE27FD7A0F00C32212 /* CardListTableViewCell.swift */; };
+		F5164AB127FD7A0F00C32212 /* CardListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F5164AAF27FD7A0F00C32212 /* CardListTableViewCell.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,8 @@
 		02DF5FB327FD6F020064FEC8 /* ToDoListUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToDoListUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		02DF5FB727FD6F020064FEC8 /* ToDoListUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListUITests.swift; sourceTree = "<group>"; };
 		02DF5FB927FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		F5164AAE27FD7A0F00C32212 /* CardListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListTableViewCell.swift; sourceTree = "<group>"; };
+		F5164AAF27FD7A0F00C32212 /* CardListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CardListTableViewCell.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +110,8 @@
 				02DF5F9F27FD6F020064FEC8 /* Assets.xcassets */,
 				02DF5FA127FD6F020064FEC8 /* LaunchScreen.storyboard */,
 				02DF5FA427FD6F020064FEC8 /* Info.plist */,
+				F5164AAE27FD7A0F00C32212 /* CardListTableViewCell.swift */,
+				F5164AAF27FD7A0F00C32212 /* CardListTableViewCell.xib */,
 			);
 			path = ToDoList;
 			sourceTree = "<group>";
@@ -234,6 +240,7 @@
 				02DF5FA327FD6F020064FEC8 /* LaunchScreen.storyboard in Resources */,
 				02DF5FA027FD6F020064FEC8 /* Assets.xcassets in Resources */,
 				02DF5F9E27FD6EFF0064FEC8 /* Main.storyboard in Resources */,
+				F5164AB127FD7A0F00C32212 /* CardListTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,6 +268,7 @@
 				02DF5F9B27FD6EFF0064FEC8 /* ViewController.swift in Sources */,
 				02DF5F9727FD6EFF0064FEC8 /* AppDelegate.swift in Sources */,
 				02DF5F9927FD6EFF0064FEC8 /* SceneDelegate.swift in Sources */,
+				F5164AB027FD7A0F00C32212 /* CardListTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ToDoList/ToDoList.xcodeproj/project.pbxproj
+++ b/ToDoList/ToDoList.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		02DF5FAE27FD6F020064FEC8 /* ToDoListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FAD27FD6F020064FEC8 /* ToDoListTests.swift */; };
 		02DF5FB827FD6F020064FEC8 /* ToDoListUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FB727FD6F020064FEC8 /* ToDoListUITests.swift */; };
 		02DF5FBA27FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FB927FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift */; };
+		02DF5FC727FD73B00064FEC8 /* CardListTableViewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF5FC627FD73B00064FEC8 /* CardListTableViewHeaderView.swift */; };
+		02DF5FC927FD73C10064FEC8 /* CardListTableViewHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02DF5FC827FD73C10064FEC8 /* CardListTableViewHeaderView.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,8 @@
 		02DF5FB327FD6F020064FEC8 /* ToDoListUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToDoListUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		02DF5FB727FD6F020064FEC8 /* ToDoListUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListUITests.swift; sourceTree = "<group>"; };
 		02DF5FB927FD6F020064FEC8 /* ToDoListUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		02DF5FC627FD73B00064FEC8 /* CardListTableViewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListTableViewHeaderView.swift; sourceTree = "<group>"; };
+		02DF5FC827FD73C10064FEC8 /* CardListTableViewHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CardListTableViewHeaderView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +107,8 @@
 				02DF5F9827FD6EFF0064FEC8 /* SceneDelegate.swift */,
 				02DF5F9A27FD6EFF0064FEC8 /* ViewController.swift */,
 				02DF5F9C27FD6EFF0064FEC8 /* Main.storyboard */,
+				02DF5FC627FD73B00064FEC8 /* CardListTableViewHeaderView.swift */,
+				02DF5FC827FD73C10064FEC8 /* CardListTableViewHeaderView.xib */,
 				02DF5F9F27FD6F020064FEC8 /* Assets.xcassets */,
 				02DF5FA127FD6F020064FEC8 /* LaunchScreen.storyboard */,
 				02DF5FA427FD6F020064FEC8 /* Info.plist */,
@@ -232,6 +238,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				02DF5FA327FD6F020064FEC8 /* LaunchScreen.storyboard in Resources */,
+				02DF5FC927FD73C10064FEC8 /* CardListTableViewHeaderView.xib in Resources */,
 				02DF5FA027FD6F020064FEC8 /* Assets.xcassets in Resources */,
 				02DF5F9E27FD6EFF0064FEC8 /* Main.storyboard in Resources */,
 			);
@@ -261,6 +268,7 @@
 				02DF5F9B27FD6EFF0064FEC8 /* ViewController.swift in Sources */,
 				02DF5F9727FD6EFF0064FEC8 /* AppDelegate.swift in Sources */,
 				02DF5F9927FD6EFF0064FEC8 /* SceneDelegate.swift in Sources */,
+				02DF5FC727FD73B00064FEC8 /* CardListTableViewHeaderView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ToDoList/ToDoList.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ToDoList/ToDoList.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ToDoList/ToDoList.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ToDoList/ToDoList.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ToDoList/ToDoList/AppDelegate.swift
+++ b/ToDoList/ToDoList/AppDelegate.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+}
+

--- a/ToDoList/ToDoList/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ToDoList/ToDoList/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDoList/ToDoList/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ToDoList/ToDoList/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDoList/ToDoList/Assets.xcassets/Contents.json
+++ b/ToDoList/ToDoList/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDoList/ToDoList/Base.lproj/LaunchScreen.storyboard
+++ b/ToDoList/ToDoList/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ToDoList/ToDoList/Base.lproj/Main.storyboard
+++ b/ToDoList/ToDoList/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="ipad11_0rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -81,7 +81,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VM1-Oe-W0G" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-92" y="763"/>
+            <point key="canvasLocation" x="-54" y="822"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="9Ln-ko-Iiz">
@@ -95,7 +95,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JzU-QP-8kh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="56" y="763"/>
+            <point key="canvasLocation" x="122" y="822"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="ihW-g8-Vma">
@@ -109,7 +109,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Bwl-Ar-Sgr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="206" y="763"/>
+            <point key="canvasLocation" x="304" y="822"/>
         </scene>
     </scenes>
     <resources>

--- a/ToDoList/ToDoList/Base.lproj/Main.storyboard
+++ b/ToDoList/ToDoList/Base.lproj/Main.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="ipad11_0rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ToDoList" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="122" y="119"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ToDoList/ToDoList/Base.lproj/Main.storyboard
+++ b/ToDoList/ToDoList/Base.lproj/Main.storyboard
@@ -15,13 +15,101 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jsA-Of-XCJ">
+                                <rect key="frame" x="48" y="120" width="256" height="694"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="256" id="3ZZ-Ax-R6X"/>
+                                </constraints>
+                                <connections>
+                                    <segue destination="Oak-C5-AVU" kind="embed" id="0hm-W4-qDj"/>
+                                </connections>
+                            </containerView>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Zy-gF-B7T">
+                                <rect key="frame" x="326" y="120" width="256" height="694"/>
+                                <connections>
+                                    <segue destination="R3d-8x-cr8" kind="embed" id="twp-aY-zGc"/>
+                                </connections>
+                            </containerView>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cFL-No-yJu">
+                                <rect key="frame" x="604" y="120" width="256" height="694"/>
+                                <connections>
+                                    <segue destination="7AS-K7-Tv0" kind="embed" id="1N0-Fe-PT3"/>
+                                </connections>
+                            </containerView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X1P-eL-nXY">
+                                <rect key="frame" x="0.0" y="0.0" width="1194" height="72"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="72" id="cWJ-yI-Ncd"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="jsA-Of-XCJ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="48" id="011-In-zxi"/>
+                            <constraint firstItem="0Zy-gF-B7T" firstAttribute="top" secondItem="jsA-Of-XCJ" secondAttribute="top" id="0Y3-b2-8Wi"/>
+                            <constraint firstItem="0Zy-gF-B7T" firstAttribute="leading" secondItem="jsA-Of-XCJ" secondAttribute="trailing" constant="22" id="1Xi-Ut-rgI"/>
+                            <constraint firstItem="cFL-No-yJu" firstAttribute="bottom" secondItem="jsA-Of-XCJ" secondAttribute="bottom" id="7dc-jN-oq8"/>
+                            <constraint firstItem="0Zy-gF-B7T" firstAttribute="bottom" secondItem="jsA-Of-XCJ" secondAttribute="bottom" id="DhZ-rA-sPH"/>
+                            <constraint firstItem="X1P-eL-nXY" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="Dlh-8q-qHJ"/>
+                            <constraint firstItem="cFL-No-yJu" firstAttribute="width" secondItem="jsA-Of-XCJ" secondAttribute="width" id="Kkn-Sf-NRk"/>
+                            <constraint firstItem="jsA-Of-XCJ" firstAttribute="top" secondItem="X1P-eL-nXY" secondAttribute="bottom" constant="48" id="PMB-48-NFX"/>
+                            <constraint firstItem="cFL-No-yJu" firstAttribute="top" secondItem="jsA-Of-XCJ" secondAttribute="top" id="ZFh-6X-GLe"/>
+                            <constraint firstItem="X1P-eL-nXY" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="efY-eP-gJN"/>
+                            <constraint firstItem="cFL-No-yJu" firstAttribute="leading" secondItem="0Zy-gF-B7T" secondAttribute="trailing" constant="22" id="gGB-rU-qWY"/>
+                            <constraint firstItem="0Zy-gF-B7T" firstAttribute="width" secondItem="jsA-Of-XCJ" secondAttribute="width" id="jMq-5N-LKY"/>
+                            <constraint firstItem="X1P-eL-nXY" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="s0T-H2-fBL"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="jsA-Of-XCJ" secondAttribute="bottom" id="zGl-yO-eUL"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="122" y="119"/>
+            <point key="canvasLocation" x="121.60804020100502" y="118.70503597122303"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="vjQ-BL-Wud">
+            <objects>
+                <viewController id="Oak-C5-AVU" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="QWk-TS-uvb">
+                        <rect key="frame" x="0.0" y="0.0" width="256" height="694"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </tableView>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="VM1-Oe-W0G" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-92" y="763"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="9Ln-ko-Iiz">
+            <objects>
+                <viewController id="R3d-8x-cr8" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="jh8-2u-v8O">
+                        <rect key="frame" x="0.0" y="0.0" width="256" height="694"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </tableView>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="JzU-QP-8kh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="56" y="763"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="ihW-g8-Vma">
+            <objects>
+                <viewController id="7AS-K7-Tv0" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="dJU-rb-Fae">
+                        <rect key="frame" x="0.0" y="0.0" width="256" height="694"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </tableView>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Bwl-Ar-Sgr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="206" y="763"/>
         </scene>
     </scenes>
     <resources>

--- a/ToDoList/ToDoList/CardListTableViewCell.swift
+++ b/ToDoList/ToDoList/CardListTableViewCell.swift
@@ -1,29 +1,17 @@
-//
-//  CardListTableViewCell.swift
-//  ToDoList
-//
-//  Created by 허태양 on 2022/04/06.
-//
-
 import UIKit
 
 class CardListTableViewCell: UITableViewCell {
 
     @IBOutlet weak var title: UILabel!
-    
     @IBOutlet weak var body: UILabel!
-    
     @IBOutlet weak var caption: UILabel!
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
     }
     
 }

--- a/ToDoList/ToDoList/CardListTableViewCell.swift
+++ b/ToDoList/ToDoList/CardListTableViewCell.swift
@@ -9,6 +9,12 @@ import UIKit
 
 class CardListTableViewCell: UITableViewCell {
 
+    @IBOutlet weak var title: UILabel!
+    
+    @IBOutlet weak var body: UILabel!
+    
+    @IBOutlet weak var caption: UILabel!
+
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code

--- a/ToDoList/ToDoList/CardListTableViewCell.swift
+++ b/ToDoList/ToDoList/CardListTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  CardListTableViewCell.swift
+//  ToDoList
+//
+//  Created by 허태양 on 2022/04/06.
+//
+
+import UIKit
+
+class CardListTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+}

--- a/ToDoList/ToDoList/CardListTableViewCell.swift
+++ b/ToDoList/ToDoList/CardListTableViewCell.swift
@@ -14,4 +14,16 @@ class CardListTableViewCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
     }
     
+    func setTitle(title: String) {
+        self.title.text = title
+    }
+    
+    func setBody(body: String) {
+        self.body.text = body
+    }
+    
+    func setCaption(caption: String) {
+        self.caption.text = "author by \(caption)"
+    }
+    
 }

--- a/ToDoList/ToDoList/CardListTableViewCell.xib
+++ b/ToDoList/ToDoList/CardListTableViewCell.xib
@@ -23,19 +23,19 @@
                 <rect key="frame" x="0.0" y="0.0" width="258" height="128"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GitHub 공부하기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCV-oe-Fnc">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCV-oe-Fnc">
                         <rect key="frame" x="16" y="16" width="226" height="23"/>
                         <fontDescription key="fontDescription" name="NotoSansOriya-Bold" family="Noto Sans Oriya" pointSize="16"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="add, commit, push" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tm5-UL-pe7">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="body" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tm5-UL-pe7">
                         <rect key="frame" x="16" y="47" width="226" height="20"/>
                         <fontDescription key="fontDescription" name="NotoSansOriya" family="Noto Sans Oriya" pointSize="14"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="author by iOS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RSg-C8-c3h">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RSg-C8-c3h">
                         <rect key="frame" x="16" y="95" width="226" height="17"/>
                         <fontDescription key="fontDescription" name="NotoSansOriya" family="Noto Sans Oriya" pointSize="12"/>
                         <color key="textColor" systemColor="systemGray4Color"/>

--- a/ToDoList/ToDoList/CardListTableViewCell.xib
+++ b/ToDoList/ToDoList/CardListTableViewCell.xib
@@ -4,20 +4,63 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardListTableViewCell" customModule="ToDoList" customModuleProvider="target">
+            <connections>
+                <outlet property="body" destination="tm5-UL-pe7" id="83t-et-LK4"/>
+                <outlet property="caption" destination="RSg-C8-c3h" id="gyX-ie-K3Z"/>
+                <outlet property="title" destination="sCV-oe-Fnc" id="hW6-GG-UsS"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="CardListTableViewCell" customModule="ToDoList" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="CardListTableViewCell" id="KGk-i7-Jjw" customClass="CardListTableViewCell" customModule="ToDoList" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="258" height="128"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM" customClass="CardListTableViewCell" customModule="ToDoList" customModuleProvider="target">
                 <rect key="frame" x="0.0" y="0.0" width="258" height="128"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GitHub 공부하기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCV-oe-Fnc">
+                        <rect key="frame" x="16" y="16" width="226" height="23"/>
+                        <fontDescription key="fontDescription" name="NotoSansOriya-Bold" family="Noto Sans Oriya" pointSize="16"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="add, commit, push" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tm5-UL-pe7">
+                        <rect key="frame" x="16" y="47" width="226" height="20"/>
+                        <fontDescription key="fontDescription" name="NotoSansOriya" family="Noto Sans Oriya" pointSize="14"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="author by iOS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RSg-C8-c3h">
+                        <rect key="frame" x="16" y="95" width="226" height="17"/>
+                        <fontDescription key="fontDescription" name="NotoSansOriya" family="Noto Sans Oriya" pointSize="12"/>
+                        <color key="textColor" systemColor="systemGray4Color"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="RSg-C8-c3h" secondAttribute="trailing" constant="16" id="H8E-Wk-qwc"/>
+                    <constraint firstAttribute="trailing" secondItem="tm5-UL-pe7" secondAttribute="trailing" constant="16" id="KHs-Ws-Ifs"/>
+                    <constraint firstItem="RSg-C8-c3h" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="PB7-8w-8cy"/>
+                    <constraint firstAttribute="bottom" secondItem="RSg-C8-c3h" secondAttribute="bottom" constant="16" id="QnN-vg-WyN"/>
+                    <constraint firstItem="sCV-oe-Fnc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="c7w-T5-ZmR"/>
+                    <constraint firstItem="tm5-UL-pe7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="chx-j0-hLy"/>
+                    <constraint firstAttribute="trailing" secondItem="sCV-oe-Fnc" secondAttribute="trailing" constant="16" id="eNv-VK-ksj"/>
+                    <constraint firstItem="tm5-UL-pe7" firstAttribute="top" secondItem="sCV-oe-Fnc" secondAttribute="bottom" constant="8" id="n1S-ZG-t47"/>
+                    <constraint firstItem="sCV-oe-Fnc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="pEK-Q5-5Di"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
-            <point key="canvasLocation" x="139" y="140"/>
+            <point key="canvasLocation" x="137.68115942028987" y="139.95535714285714"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemGray4Color">
+            <color red="0.81960784313725488" green="0.81960784313725488" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/ToDoList/ToDoList/CardListTableViewCell.xib
+++ b/ToDoList/ToDoList/CardListTableViewCell.xib
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="CardListTableViewCell" customModule="ToDoList" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="258" height="128"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="258" height="128"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="139" y="140"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/ToDoList/ToDoList/CardListTableViewHeaderView.swift
+++ b/ToDoList/ToDoList/CardListTableViewHeaderView.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+class CardListTableViewHeaderView: UITableViewHeaderFooterView {
+    
+    static let identifier = "CardListTableViewHeaderView"
+
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var badgeStackView: UIStackView!
+    @IBOutlet weak var badgeLabel: UILabel!
+    @IBOutlet weak var addCardButton: UIButton!
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        
+        commonInit()
+    }
+    
+    func configure(title: String) {
+        self.titleLabel.text = title
+        self.badgeLabel.text = "0"
+    }
+    
+    private func commonInit() {
+        if let view = Bundle.main.loadNibNamed(CardListTableViewHeaderView.identifier, owner: self, options: nil)?.first as? UIView {
+            view.frame = self.bounds
+            addSubview(view)
+        }
+        self.badgeStackView.clipsToBounds = true
+        self.badgeStackView.layer.cornerRadius = self.badgeStackView.frame.height/2
+    }
+    
+    func changeCardCount(to number: Int) {
+        self.badgeLabel.text = "\(number)"
+    }
+}

--- a/ToDoList/ToDoList/CardListTableViewHeaderView.xib
+++ b/ToDoList/ToDoList/CardListTableViewHeaderView.xib
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardListTableViewHeaderView" customModule="ToDoList" customModuleProvider="target">
+            <connections>
+                <outlet property="addCardButton" destination="Lqk-ho-Qm2" id="uHr-kQ-BDB"/>
+                <outlet property="badgeLabel" destination="8aE-Xt-gFd" id="lVp-ua-EBn"/>
+                <outlet property="badgeStackView" destination="p6D-rt-rj8" id="cVE-LS-4M1"/>
+                <outlet property="titleLabel" destination="4go-eJ-44s" id="ehg-HH-1aI"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="CardListTableViewHeaderView">
+            <rect key="frame" x="0.0" y="0.0" width="256" height="26"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4go-eJ-44s">
+                    <rect key="frame" x="8" y="0.0" width="37" height="26"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="26" id="2cm-3G-qWs"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="NotoSansOriya-Bold" family="Noto Sans Oriya" pointSize="18"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lqk-ho-Qm2">
+                    <rect key="frame" x="229" y="6" width="14" height="14"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="13.789999999999999" id="ezN-fX-kG2"/>
+                        <constraint firstAttribute="width" constant="13.789999999999999" id="yuq-i7-bNB"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system">
+                        <color key="baseForegroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </buttonConfiguration>
+                </button>
+                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" distribution="fillProportionally" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="p6D-rt-rj8" userLabel="Badge StackView">
+                    <rect key="frame" x="53" y="0.0" width="25.5" height="26"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="50" placeholderIntrinsicHeight="26" translatesAutoresizingMaskIntoConstraints="NO" id="4LZ-DF-0KG">
+                            <rect key="frame" x="0.0" y="0.0" width="9.5" height="26"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="26" id="2J6-c2-A87"/>
+                                <constraint firstAttribute="width" constant="9.5" id="MhV-L3-c1t"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8aE-Xt-gFd" userLabel="count">
+                            <rect key="frame" x="9.5" y="0.0" width="6.5" height="26"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="26" id="D3m-Sz-OaT"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" name="NotoSansOriya" family="Noto Sans Oriya" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="50" placeholderIntrinsicHeight="26" translatesAutoresizingMaskIntoConstraints="NO" id="3Ri-zS-Bcs">
+                            <rect key="frame" x="16" y="0.0" width="9.5" height="26"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="9.5" id="Zxg-q6-fyx"/>
+                                <constraint firstAttribute="height" constant="26" id="gf7-Me-Hsc"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemGray2Color"/>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemGray6Color"/>
+            <constraints>
+                <constraint firstItem="4go-eJ-44s" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="0Ui-7P-yPz"/>
+                <constraint firstAttribute="trailing" secondItem="Lqk-ho-Qm2" secondAttribute="trailing" constant="13.109999999999999" id="1tF-h4-JnW"/>
+                <constraint firstItem="p6D-rt-rj8" firstAttribute="leading" secondItem="4go-eJ-44s" secondAttribute="trailing" constant="8" id="3bZ-hw-76o"/>
+                <constraint firstItem="4go-eJ-44s" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="LCP-Fv-aJu"/>
+                <constraint firstItem="Lqk-ho-Qm2" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="ea6-pu-hhG"/>
+                <constraint firstItem="p6D-rt-rj8" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="hHw-m8-XHr"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="140.57971014492756" y="55.580357142857139"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ToDoList/ToDoList/Info.plist
+++ b/ToDoList/ToDoList/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ToDoList/ToDoList/SceneDelegate.swift
+++ b/ToDoList/ToDoList/SceneDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+}
+

--- a/ToDoList/ToDoList/ViewController.swift
+++ b/ToDoList/ToDoList/ViewController.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+
+}
+

--- a/ToDoList/ToDoListTests/ToDoListTests.swift
+++ b/ToDoList/ToDoListTests/ToDoListTests.swift
@@ -1,0 +1,5 @@
+import XCTest
+@testable import ToDoList
+
+class ToDoListTests: XCTestCase {
+}

--- a/ToDoList/ToDoListUITests/ToDoListUITests.swift
+++ b/ToDoList/ToDoListUITests/ToDoListUITests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+class ToDoListUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func testExample() throws {
+        let app = XCUIApplication()
+        app.launch()
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/ToDoList/ToDoListUITests/ToDoListUITestsLaunchTests.swift
+++ b/ToDoList/ToDoListUITests/ToDoListUITestsLaunchTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+class ToDoListUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
안녕하세요 team 10의 iOS를 담당하고 있는 Sol, Ocean입니다.
이번 주에는 그라운드 룰을 정하고, 업무를 나누는 것에 대해 생각을 해보다보니, 진행 정도가 더뎠습니다. 지금까지 진행한 부분까지만 정리해서 PR 보내도록 하겠습니다!
|CardListTableViewCell.xib |CardListTableViewHeaderView.xib|
|---|---|
|![SS 2022-04-06 PM 06 45 50](https://user-images.githubusercontent.com/92504186/161947493-928bed44-5ddd-473d-9ae8-6908068b0777.jpg)|![SS 2022-04-06 PM 06 46 05](https://user-images.githubusercontent.com/92504186/161947550-62ddaeea-69a6-40b5-ae2c-054c699e040d.jpg)|
## 작업 목록
- [x] 메인 뷰의 카드 리스트로 사용할 테이블 뷰 구현 [Sol + Ocean]
  - [x] 테이블 뷰의 HeaderView로 사용할 CardListViewHeaderView 클래스 및 xib 구현 [Sol]
  - [x] 테이블 뷰의 Cell로 사용할 CardListViewCell 클래스 및 xib 구현 [Ocean]
---

## 학습 키워드
`UITableView` , `UITableViewCell` , `UITalbeViewHeaderView` , `cornerRadius`

---

## 고민과 해결
- [Sol] HeaderView의 Badge에 해당하는 동그란 layer를 가지는 Label을 구현하기 위해 Label의 layer의 cornerRadius를 사용하는 방법을 사용하고자 했지만, Label에 포함되있는 텍스트의 길이가 길어지거나 짧아질 경우에는 해당 모양이 동그란 모양이 되지 않았습니다. 이를 해결하기 위해, Label 양 옆에 빈 UIView를 넣고, UIView, Label, UIView 순서로 스택뷰에 넣은 후, 스택뷰의 layer cornerRadius를 사용해 둥근 모양의 Label을 만들 수 있었습니다.
- [Ocean] 해야할 일, 하고 있는 일, 완료한 일의 구성이 같기에, tableView를 사용하고 싶었습니다. 하지만, tableView를 두 번 사용할 수 없어서, 같은 구성의 tableView를 세 개 만들었습니다. 이 중복을 해결하는 방법이 궁금합니다.