### PR TITLE
[Team-05 BE nathan & 피오] 카드 생성 기능 구현(미완)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'mysql:mysql-connector-java'
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/team05/todolist/controller/CardController.java
+++ b/backend/src/main/java/com/team05/todolist/controller/CardController.java
@@ -2,9 +2,12 @@ package com.team05.todolist.controller;
 
 import com.team05.todolist.domain.Card;
 import com.team05.todolist.domain.Event;
+import com.team05.todolist.domain.Log;
 import com.team05.todolist.domain.dto.CardDTO;
 import com.team05.todolist.domain.dto.LogDTO;
 import com.team05.todolist.domain.dto.ResponseDTO;
+import com.team05.todolist.service.CardService;
+import com.team05.todolist.service.LogService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -27,12 +30,11 @@ public class CardController {
 	}
 
 	@PostMapping("/cards")
-	public ResponseEntity<ResponseDTO> create(CardDTO cardDto) {
-		CardDTO card = cardService.save(cardDto);
+	public ResponseEntity<LogDTO> create(CardDTO cardDto) {
+		cardService.save(cardDto);
 		LogDTO log = logService.save(Event.CREATE, cardDto);
-		ResponseDTO responseDTO = new ResponseDTO(card, log);
-		logger.debug("card-{}: {}, log: {}({})", card.getCardId(), card.getTitle(),
-			log.getLogEvent(), log.getLogTime());
-		return ResponseEntity.ok().body(responseDTO);
+
+		logger.debug("card: {}, log: {}({})", cardDto.getTitle(), log.getLogEvent(), log.getLogTime());
+		return ResponseEntity.ok().body(log);
 	}
 }

--- a/backend/src/main/java/com/team05/todolist/controller/CardController.java
+++ b/backend/src/main/java/com/team05/todolist/controller/CardController.java
@@ -1,0 +1,38 @@
+package com.team05.todolist.controller;
+
+import com.team05.todolist.domain.Card;
+import com.team05.todolist.domain.Event;
+import com.team05.todolist.domain.dto.CardDTO;
+import com.team05.todolist.domain.dto.LogDTO;
+import com.team05.todolist.domain.dto.ResponseDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api")
+public class CardController {
+
+	private final CardService cardService;
+	private final LogService logService;
+	private Logger logger = LoggerFactory.getLogger(CardController.class);
+
+	public CardController(CardService cardService, LogService logService) {
+		this.cardService = cardService;
+		this.logService = logService;
+	}
+
+	@PostMapping("/cards")
+	public ResponseEntity<ResponseDTO> create(CardDTO cardDto) {
+		CardDTO card = cardService.save(cardDto);
+		LogDTO log = logService.save(Event.CREATE, cardDto);
+		ResponseDTO responseDTO = new ResponseDTO(card, log);
+		logger.debug("card-{}: {}, log: {}({})", card.getCardId(), card.getTitle(),
+			log.getLogEvent(), log.getLogTime());
+		return ResponseEntity.ok().body(responseDTO);
+	}
+}

--- a/backend/src/main/java/com/team05/todolist/domain/Card.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Card.java
@@ -1,28 +1,43 @@
 package com.team05.todolist.domain;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
 public class Card {
 
 	private Integer id;
 	private Integer orderIndex;
-	private Integer delete;
+	private Integer deleteYN;
 	private String title;
 	private String content;
 	private Section section;
 
-	public Card(Integer orderIndex, Integer delete, String title, String content, String section) {
+	public Card(Integer orderIndex, Integer deleteYN, String title, String content, String section) {
 		this.orderIndex = orderIndex;
-		this.delete = delete;
+		this.deleteYN = deleteYN;
 		this.title = title;
 		this.content = content;
-		this.section = Section.valueOf(section);
+		this.section = Section.getSection(section);
 	}
 
 	public void setId(Integer id) {
 		this.id = id;
+	}
+
+	public Integer getOrderIndex() {
+		return orderIndex;
+	}
+
+	public Integer getDeleteYN() {
+		return deleteYN;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public String getSectionType() {
+		return section.getSectionType();
 	}
 }

--- a/backend/src/main/java/com/team05/todolist/domain/Card.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Card.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 public class Card {
 
 	private Integer id;
@@ -15,12 +14,15 @@ public class Card {
 	private String content;
 	private Section section;
 
-	public Card(Integer orderIndex, Integer delete, String title, String content, Section section) {
+	public Card(Integer orderIndex, Integer delete, String title, String content, String section) {
 		this.orderIndex = orderIndex;
 		this.delete = delete;
 		this.title = title;
 		this.content = content;
-		this.section = section;
+		this.section = Section.valueOf(section);
 	}
 
+	public void setId(Integer id) {
+		this.id = id;
+	}
 }

--- a/backend/src/main/java/com/team05/todolist/domain/Card.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Card.java
@@ -1,0 +1,26 @@
+package com.team05.todolist.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Card {
+
+	private Integer id;
+	private Integer orderIndex;
+	private Integer delete;
+	private String title;
+	private String content;
+	private Section section;
+
+	public Card(Integer orderIndex, Integer delete, String title, String content, Section section) {
+		this.orderIndex = orderIndex;
+		this.delete = delete;
+		this.title = title;
+		this.content = content;
+		this.section = section;
+	}
+
+}

--- a/backend/src/main/java/com/team05/todolist/domain/Event.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Event.java
@@ -1,7 +1,13 @@
 package com.team05.todolist.domain;
 
 public enum Event {
-	CREATE,
-	MOVE,
-	DELETE
+	CREATE("create"),
+	MOVE("move"),
+	DELETE("delete");
+
+	private final String eventType;
+
+	Event(String eventType) {
+		this.eventType = eventType;
+	}
 }

--- a/backend/src/main/java/com/team05/todolist/domain/Event.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Event.java
@@ -1,0 +1,7 @@
+package com.team05.todolist.domain;
+
+public enum Event {
+	CREATE,
+	MOVE,
+	DELETE
+}

--- a/backend/src/main/java/com/team05/todolist/domain/Log.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Log.java
@@ -1,0 +1,21 @@
+package com.team05.todolist.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class Log {
+
+	private Integer id;
+	private Event event;
+	private LocalDateTime logTime;
+
+	public Log(Event event, LocalDateTime logTime) {
+		this.event = event;
+		this.logTime = logTime;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+}

--- a/backend/src/main/java/com/team05/todolist/domain/Log.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Log.java
@@ -1,21 +1,45 @@
 package com.team05.todolist.domain;
 
 import java.time.LocalDateTime;
-import lombok.Getter;
 
-@Getter
 public class Log {
 
 	private Integer id;
 	private Event event;
 	private LocalDateTime logTime;
+	private String title;
+	private String prevSection;
+	private String section;
 
-	public Log(Event event, LocalDateTime logTime) {
+	public Log(Event event, LocalDateTime logTime, String title, String prevSection, String section) {
 		this.event = event;
 		this.logTime = logTime;
+		this.title = title;
+		this.prevSection = prevSection;
+		this.section = section;
 	}
 
 	public void setId(Integer id) {
 		this.id = id;
+	}
+
+	public String getEvent() {
+		return event.name();
+	}
+
+	public LocalDateTime getLogTime() {
+		return logTime;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getPrevSection() {
+		return prevSection;
+	}
+
+	public String getSection() {
+		return section;
 	}
 }

--- a/backend/src/main/java/com/team05/todolist/domain/Section.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Section.java
@@ -1,0 +1,7 @@
+package com.team05.todolist.domain;
+
+public enum Section {
+	TODO,
+	DOING,
+	DONE
+}

--- a/backend/src/main/java/com/team05/todolist/domain/Section.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Section.java
@@ -1,5 +1,8 @@
 package com.team05.todolist.domain;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 public enum Section {
 	TODO("todo"),
 	DOING("doing"),
@@ -9,5 +12,20 @@ public enum Section {
 
 	Section(String sectionType) {
 		this.sectionType = sectionType;
+	}
+
+	public String getSectionType() {
+		return sectionType;
+	}
+
+	public static Section getSection(String section) {
+		return Arrays.stream(Section.values())
+			.filter(c -> c.isSameSection(section))
+			.findAny()
+			.orElseThrow();
+	}
+
+	private boolean isSameSection(String section) {
+		return this.sectionType.equals(section);
 	}
 }

--- a/backend/src/main/java/com/team05/todolist/domain/Section.java
+++ b/backend/src/main/java/com/team05/todolist/domain/Section.java
@@ -1,7 +1,13 @@
 package com.team05.todolist.domain;
 
 public enum Section {
-	TODO,
-	DOING,
-	DONE
+	TODO("todo"),
+	DOING("doing"),
+	DONE("done");
+
+	private final String sectionType;
+
+	Section(String sectionType) {
+		this.sectionType = sectionType;
+	}
 }

--- a/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
+++ b/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 public class CardDTO {
 
 	private Integer cardId;
@@ -12,10 +11,13 @@ public class CardDTO {
 	private String title;
 	private String content;
 
-	public CardDTO(Integer cardId, Integer orderIndex, String title, String content) {
-		this.cardId = cardId;
+	public CardDTO(Integer orderIndex, String title, String content) {
 		this.orderIndex = orderIndex;
 		this.title = title;
 		this.content = content;
+	}
+
+	public void setCardId(Integer cardId) {
+		this.cardId = cardId;
 	}
 }

--- a/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
+++ b/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
@@ -1,0 +1,21 @@
+package com.team05.todolist.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CardDTO {
+
+	private Integer cardId;
+	private Integer orderIndex;
+	private String title;
+	private String content;
+
+	public CardDTO(Integer cardId, Integer orderIndex, String title, String content) {
+		this.cardId = cardId;
+		this.orderIndex = orderIndex;
+		this.title = title;
+		this.content = content;
+	}
+}

--- a/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
+++ b/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
@@ -1,5 +1,6 @@
 package com.team05.todolist.domain.dto;
 
+import com.team05.todolist.domain.Section;
 import lombok.Getter;
 
 @Getter
@@ -9,11 +10,13 @@ public class CardDTO {
 	private Integer orderIndex;
 	private String title;
 	private String content;
+	private String section;
 
-	public CardDTO(Integer orderIndex, String title, String content) {
+	public CardDTO(Integer orderIndex, String title, String content, String section) {
 		this.orderIndex = orderIndex;
 		this.title = title;
 		this.content = content;
+		this.section = section;
 	}
 
 	public void setCardId(Integer cardId) {

--- a/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
+++ b/backend/src/main/java/com/team05/todolist/domain/dto/CardDTO.java
@@ -1,7 +1,6 @@
 package com.team05.todolist.domain.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 public class CardDTO {

--- a/backend/src/main/java/com/team05/todolist/domain/dto/LogDTO.java
+++ b/backend/src/main/java/com/team05/todolist/domain/dto/LogDTO.java
@@ -10,11 +10,18 @@ public class LogDTO {
 	private Integer logId;
 	private Event logEvent;
 	private LocalDateTime logTime;
+	private String title;
+	private String prevSection;
+	private String section;
 
-	public LogDTO(Integer logId, Event logEvent, LocalDateTime logTime) {
+	public LogDTO(Integer logId, String logEvent, LocalDateTime logTime, String title,
+		String prevSection, String section) {
 		this.logId = logId;
-		this.logEvent = logEvent;
+		this.logEvent = Event.valueOf(logEvent);
 		this.logTime = checkDateTimeNull(logTime);
+		this.title = title;
+		this.prevSection = prevSection;
+		this.section = section;
 	}
 
 	private LocalDateTime checkDateTimeNull(LocalDateTime logTime) {

--- a/backend/src/main/java/com/team05/todolist/domain/dto/LogDTO.java
+++ b/backend/src/main/java/com/team05/todolist/domain/dto/LogDTO.java
@@ -1,0 +1,26 @@
+package com.team05.todolist.domain.dto;
+
+import com.team05.todolist.domain.Event;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class LogDTO {
+
+	private Integer logId;
+	private Event logEvent;
+	private LocalDateTime logTime;
+
+	public LogDTO(Integer logId, Event logEvent, LocalDateTime logTime) {
+		this.logId = logId;
+		this.logEvent = logEvent;
+		this.logTime = checkDateTimeNull(logTime);
+	}
+
+	private LocalDateTime checkDateTimeNull(LocalDateTime logTime) {
+		if (logTime == null) {
+			return LocalDateTime.now();
+		}
+		return logTime;
+	}
+}

--- a/backend/src/main/java/com/team05/todolist/domain/dto/ResponseDTO.java
+++ b/backend/src/main/java/com/team05/todolist/domain/dto/ResponseDTO.java
@@ -1,0 +1,12 @@
+package com.team05.todolist.domain.dto;
+
+public class ResponseDTO {
+
+	private CardDTO card;
+	private LogDTO log;
+
+	public ResponseDTO(CardDTO cardDto, LogDTO logDto) {
+		this.card = cardDto;
+		this.log = logDto;
+	}
+}

--- a/backend/src/main/java/com/team05/todolist/repository/CardRepository.java
+++ b/backend/src/main/java/com/team05/todolist/repository/CardRepository.java
@@ -1,0 +1,14 @@
+package com.team05.todolist.repository;
+
+import com.team05.todolist.domain.Card;
+import java.util.List;
+import java.util.Optional;
+
+public interface CardRepository {
+
+    void save(Card card);
+    void delete(int id);
+    List<Card> findAll();
+    Optional<Card> findById(int id);
+
+}

--- a/backend/src/main/java/com/team05/todolist/repository/JdbcCardRepository.java
+++ b/backend/src/main/java/com/team05/todolist/repository/JdbcCardRepository.java
@@ -1,14 +1,42 @@
 package com.team05.todolist.repository;
 
 import com.team05.todolist.domain.Card;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public class JdbcCardRepository implements CardRepository {
+
+    private JdbcTemplate jdbcTemplate;
+    private SimpleJdbcInsert simpleJdbcInsert;
+
+    public JdbcCardRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.simpleJdbcInsert = new SimpleJdbcInsert(dataSource)
+            .withTableName("card")
+            .usingGeneratedKeyColumns("id");
+    }
 
     @Override
     public void save(Card card) {
+        Map<String, Object> params = getSaveParams(card);
+        simpleJdbcInsert.executeAndReturnKey(params).intValue();
+    }
 
+    private Map<String, Object> getSaveParams(Card card) {
+        Map<String, Object> params = new HashMap();
+        params.put("order_index", card.getOrderIndex());
+        params.put("delete_yn", card.getDeleteYN());
+        params.put("title", card.getTitle());
+        params.put("content", card.getContent());
+        params.put("section", card.getSectionType());
+        return params;
     }
 
     @Override

--- a/backend/src/main/java/com/team05/todolist/repository/JdbcCardRepository.java
+++ b/backend/src/main/java/com/team05/todolist/repository/JdbcCardRepository.java
@@ -1,0 +1,28 @@
+package com.team05.todolist.repository;
+
+import com.team05.todolist.domain.Card;
+import java.util.List;
+import java.util.Optional;
+
+public class JdbcCardRepository implements CardRepository {
+
+    @Override
+    public void save(Card card) {
+
+    }
+
+    @Override
+    public void delete(int id) {
+
+    }
+
+    @Override
+    public List<Card> findAll() {
+        return null;
+    }
+
+    @Override
+    public Optional<Card> findById(int id) {
+        return Optional.empty();
+    }
+}

--- a/backend/src/main/java/com/team05/todolist/repository/JdbcLogRepository.java
+++ b/backend/src/main/java/com/team05/todolist/repository/JdbcLogRepository.java
@@ -1,15 +1,41 @@
 package com.team05.todolist.repository;
 
 import com.team05.todolist.domain.Log;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class JdbcLogRepository implements LogRepository {
 
-    @Override
-    public void save(Log log) {
+    private JdbcTemplate jdbcTemplate;
+    private SimpleJdbcInsert simpleJdbcInsert;
 
+    public JdbcLogRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.simpleJdbcInsert = new SimpleJdbcInsert(dataSource)
+            .withTableName("log")
+            .usingGeneratedKeyColumns("id");
+    }
+
+    @Override
+    public int save(Log log) {
+        Map<String, Object> params = getSaveParams(log);
+        return simpleJdbcInsert.executeAndReturnKey(params).intValue();
+    }
+
+    private Map<String, Object> getSaveParams(Log log) {
+        Map<String, Object> params = new HashMap();
+        params.put("event", log.getEvent());
+        params.put("log_time", log.getLogTime());
+        params.put("title", log.getTitle());
+        params.put("prev_section", log.getPrevSection());
+        params.put("section", log.getSection());
+        return params;
     }
 
     @Override

--- a/backend/src/main/java/com/team05/todolist/repository/JdbcLogRepository.java
+++ b/backend/src/main/java/com/team05/todolist/repository/JdbcLogRepository.java
@@ -1,0 +1,19 @@
+package com.team05.todolist.repository;
+
+import com.team05.todolist.domain.Log;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcLogRepository implements LogRepository {
+
+    @Override
+    public void save(Log log) {
+
+    }
+
+    @Override
+    public List<Log> findAll() {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/team05/todolist/repository/LogRepository.java
+++ b/backend/src/main/java/com/team05/todolist/repository/LogRepository.java
@@ -1,0 +1,11 @@
+package com.team05.todolist.repository;
+
+import com.team05.todolist.domain.Log;
+import java.util.List;
+
+public interface LogRepository {
+
+    void save(Log log);
+    List<Log> findAll();
+
+}

--- a/backend/src/main/java/com/team05/todolist/repository/LogRepository.java
+++ b/backend/src/main/java/com/team05/todolist/repository/LogRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface LogRepository {
 
-    void save(Log log);
+    int save(Log log);
     List<Log> findAll();
 
 }

--- a/backend/src/main/java/com/team05/todolist/service/CardService.java
+++ b/backend/src/main/java/com/team05/todolist/service/CardService.java
@@ -1,0 +1,51 @@
+package com.team05.todolist.service;
+
+import com.team05.todolist.controller.RequestCardDto;
+import com.team05.todolist.controller.ResponseCardDto;
+import com.team05.todolist.domain.Card;
+import com.team05.todolist.domain.Log;
+import com.team05.todolist.repository.CardRepository;
+import com.team05.todolist.repository.LogRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CardService {
+
+    private final CardRepository cardRepository;
+    private final LogRepository logRepository;
+
+    public CardService(CardRepository cardRepository, LogRepository logRepository) {
+        this.cardRepository = cardRepository;
+        this.logRepository = logRepository;
+    }
+
+    public List<Card> findCards() {
+        return cardRepository.findAll();
+    }
+
+    public List<Log> findLogs() {
+        return logRepository.findAll();
+    }
+
+    public ResponseCardDto findOne(int id) throws NoSuchElementException {
+        Optional<Card> card = cardRepository.findById(id);
+        return card.orElseThrow();
+    }
+
+    public void update(RequestCardDto updateCardDto) {
+        Card updateTargetCard = findOne(updateCardDto.getId());
+        updateTargetCard.changeSection(updateCardDto.getSection());
+        updateTargetCard.changeTitle(updateCardDto.getTitle());
+        updateTargetCard.changeContent(updateCardDto.getContent());
+        updateTargetCard.changeOrderIndex(updateCardDto.getOrderIndex());
+
+        cardRepository.save(updateTargetCard);
+    }
+
+    public void delete(RequestCardDto requestCardDto) {
+
+    }
+}

--- a/backend/src/main/java/com/team05/todolist/service/CardService.java
+++ b/backend/src/main/java/com/team05/todolist/service/CardService.java
@@ -1,51 +1,53 @@
 package com.team05.todolist.service;
 
-import com.team05.todolist.controller.RequestCardDto;
-import com.team05.todolist.controller.ResponseCardDto;
 import com.team05.todolist.domain.Card;
-import com.team05.todolist.domain.Log;
+import com.team05.todolist.domain.dto.CardDTO;
 import com.team05.todolist.repository.CardRepository;
-import com.team05.todolist.repository.LogRepository;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CardService {
 
+    private static final Integer NON_DELETED = 0;
+
     private final CardRepository cardRepository;
-    private final LogRepository logRepository;
 
-    public CardService(CardRepository cardRepository, LogRepository logRepository) {
+    public CardService(CardRepository cardRepository) {
         this.cardRepository = cardRepository;
-        this.logRepository = logRepository;
     }
 
-    public List<Card> findCards() {
-        return cardRepository.findAll();
-    }
+    public void save(CardDTO cardDto) {
+        Card card = new Card(cardDto.getOrderIndex(), NON_DELETED, cardDto.getTitle(), cardDto.getContent(),
+            cardDto.getSection());
 
-    public List<Log> findLogs() {
-        return logRepository.findAll();
-    }
-
-    public ResponseCardDto findOne(int id) throws NoSuchElementException {
-        Optional<Card> card = cardRepository.findById(id);
-        return card.orElseThrow();
-    }
-
-    public void update(RequestCardDto updateCardDto) {
-        Card updateTargetCard = findOne(updateCardDto.getId());
-        updateTargetCard.changeSection(updateCardDto.getSection());
-        updateTargetCard.changeTitle(updateCardDto.getTitle());
-        updateTargetCard.changeContent(updateCardDto.getContent());
-        updateTargetCard.changeOrderIndex(updateCardDto.getOrderIndex());
-
-        cardRepository.save(updateTargetCard);
-    }
-
-    public void delete(RequestCardDto requestCardDto) {
+        cardRepository.save(card);
 
     }
+
+//    public List<Card> findCards() {
+//        return cardRepository.findAll();
+//    }
+
+//    public List<Log> findLogs() {
+//        return logRepository.findAll();
+//    }
+
+//    public ResponseCardDto findOne(int id) throws NoSuchElementException {
+//        Optional<Card> card = cardRepository.findById(id);
+//        return card.orElseThrow();
+//    }
+//
+//    public void update(RequestCardDto updateCardDto) {
+//        Card updateTargetCard = findOne(updateCardDto.getId());
+//        updateTargetCard.changeSection(updateCardDto.getSection());
+//        updateTargetCard.changeTitle(updateCardDto.getTitle());
+//        updateTargetCard.changeContent(updateCardDto.getContent());
+//        updateTargetCard.changeOrderIndex(updateCardDto.getOrderIndex());
+//
+//        cardRepository.save(updateTargetCard);
+//    }
+//
+//    public void delete(RequestCardDto requestCardDto) {
+//
+//    }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,13 @@
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+# do not set two of datasource.
+# spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.driverClassName=org.h2.Driver
+
+# In-Memory mode
+spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+


### PR DESCRIPTION
안녕하세요 roach! 팀 프로젝트 5조 피오와 나단입니다.
저희는 우선 카드 생성 기능을 작성하다가 PR 기간을 앞두고 급하게 머지하게 됐습니다.
이 점 죄송하다는 말씀드리고, 다음 PR부터는 마감기한을 잘 지킬 수 있도록 하겠습니다.
부족한 점이 많지만, 이번 PR도 잘 부탁드리겠습니다. 항상 감사합니다.

---

지난 수요일 이후 변경사항은 다음과 같습니다.
- domain(Card, Login) 생성
- DTO(Card, Login) 생성
- 카드 생성 기능 구현 중
  - CardController 생성
  - CardService 생성
  - LogService 생성
  - CardRepository 생성
  - LogRepository 생성

---

## 고민점

#### 협업

JK 수업을 듣고, 기능을 중심으로 분업하지 않고, 기능을 쪼개어 여러 개의 task로 분류한 뒤 협업을 해보고자 하였습니다.
task 분류를 할 때, 공통적인 부분에 대한 고려가 부족하여, 계층 간 주고받는 타입의 결정, 변동 사항에 대한 대응 미흡 등으로 나타나게 되었습니다.
이렇게 task를 분류할 때 각 계층별로 하게 되니 위와 같은 에러사항 때문에 협업이 제대로 이루어지지 못한다는 느낌을 많이 받았습니다.
현업에서도 기능 하나를 개발할 때 하나의 기능을 여러 개의 task로 나누고, 이를 각자 맡아서 진행하게 되는 것인지 궁금합니다.

#### DB
- Client 측에서 변동사항(조회, 삽입, 삭제, 변경)이 생길 때마다 api를 호출하게 되면, 그만큼 Server 쪽에 부담이 많이 될 것 같은데, 이를 해결할 수 있는 방안이 있는지 궁금합니다.
- DB table 설계시 api 호출에 대한 작업등을 고려하다보니, 자료구조 선정에 대하여 아래와 같은 고민을 하게 되었습니다.

Card의 조회, 삽입, 삭제, 수정과 같은 작업시, 
테이블의 필드로 order_index를 두어 리스트 형태의 자료구조로 관리를 할지, next_card를 두어 링크드 리스트의 형태로 관리를 해야할지 고민이 많이 됐습니다.
- order_index의 경우 조회에서 유리하지만, 예를 들어 todo에서 doing으로의 Card 이동이 생길 때, 
  만약 doing에서 30개의 카드가 존재하고, 3번째에 해당하는 곳으로 이동한다고 하면, 기존의 3번째에 있던 Card부터 나머지 Card까지
  모두 order_index를 바꿔주어야 하는데, 이 때 DB에 많은 부담이 될 것으로 생각이 되었습니다.
- next_card를 사용하면, 아무리 Card가 뒤에 많이 있어도, next_card 값을 변경해야하는 Card가 적기 때문에 부담이 덜할 것 같았습니다.
  허나 안드로이드 팀과 페이징시에 각 section별로 10개의 Card 데이터를 내려주는 것으로 협의를 했는데, 
  이를 next_card를 사용하여 조회하면, DB에서 조회하는 데에 많은 부담이 될 것으로 생각이 되었습니다.
  그렇다고 해서, 매번 페이징이 일어날 때마다 모든 Card 데이터를 DB에서 가져와서 순서를 맞춰 내려주자니.. 그것도 아닌 것 같다는 생각이 들었습니다.
- 페이징 요청이 갱신 요청에 비해서는 덜 일어날 것으로 생각이 들어 링크드 리스트를 택할까 고민을 했다가, 기능 구현을 하나도 못한 상태였기 때문에, 
  비교적 구현이 쉬운 리스트 형태의 자료구조를 택하게 되었습니다.