### PR TITLE
[team-01][BE] API - Todo 삭제 기능

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -22,8 +22,9 @@ dependencies {
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // h2
-    runtimeOnly 'com.h2database:h2'
+    // DB
+    implementation 'mysql:mysql-connector-java'
+    runtimeOnly 'com.h2database:h2' // Test
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     // lombok
     implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     // h2
     runtimeOnly 'com.h2database:h2'

--- a/BE/src/main/java/codesquad/be/todoserver/config/WebConfig.java
+++ b/BE/src/main/java/codesquad/be/todoserver/config/WebConfig.java
@@ -1,6 +1,15 @@
 package codesquad.be.todoserver.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.method.HandlerTypePredicate;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
@@ -10,10 +19,27 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableWebMvc
 public class WebConfig implements WebMvcConfigurer {
 
+	private static final String dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss";
+
 	@Override
 	public void configurePathMatch(PathMatchConfigurer configurer) {
 		configurer
 			.addPathPrefix("/api",
 				HandlerTypePredicate.forBasePackage("codesquad.be.todoserver.controller"));
+	}
+
+	@Override
+	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimeFormat);
+		LocalDateTimeSerializer localDateTimeSerializer = new LocalDateTimeSerializer(formatter);
+		LocalDateTimeDeserializer localDateTimeDeserializer = new LocalDateTimeDeserializer(
+			formatter);
+
+		JavaTimeModule module = new JavaTimeModule();
+		module.addSerializer(LocalDateTime.class, localDateTimeSerializer);
+		module.addDeserializer(LocalDateTime.class, localDateTimeDeserializer);
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(module);
+		converters.add(0, new MappingJackson2HttpMessageConverter(mapper));
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
+++ b/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
@@ -6,6 +6,7 @@ import codesquad.be.todoserver.service.TodoService;
 import java.util.List;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,5 +37,11 @@ public class TodoController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public Todo registerTodo(@Valid @RequestBody RegisterTodoDto registerTodoDto) {
 		return todoService.registerTodo(registerTodoDto);
+	}
+
+	@DeleteMapping("/todos/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteTodo(@PathVariable Long id) {
+		todoService.deleteById(id);
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/domain/Action.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/Action.java
@@ -1,8 +1,23 @@
 package codesquad.be.todoserver.domain;
 
+import java.util.function.Function;
+
 public enum Action {
-	ADD,
-	REMOVE,
-	MOVE,
-	UPDATE;
+
+	ADD(todo -> new History(todo.getId(), todo.getTitle(), todo.getUser(), "add",
+		"", todo.getStatus())),
+	REMOVE(todo -> new History(todo.getId(), todo.getTitle(), todo.getUser(), "remove",
+		"", todo.getStatus()));
+
+
+	private final Function<Todo, History> fuc;
+
+	Action(Function<Todo, History> fuc) {
+		this.fuc = fuc;
+	}
+
+	public History createHistoryBy(Todo todo) {
+		return fuc.apply(todo);
+	}
+
 }

--- a/BE/src/main/java/codesquad/be/todoserver/domain/Action.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/Action.java
@@ -1,0 +1,8 @@
+package codesquad.be.todoserver.domain;
+
+public enum Action {
+	ADD,
+	REMOVE,
+	MOVE,
+	UPDATE;
+}

--- a/BE/src/main/java/codesquad/be/todoserver/domain/History.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/History.java
@@ -2,8 +2,10 @@ package codesquad.be.todoserver.domain;
 
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class History {
 
 	private Long id;
@@ -39,18 +41,7 @@ public class History {
 	}
 
 	public static History of(Todo todo, Action action) {
-		switch (action) {
-			case ADD:
-				return new History(todo.getId(), todo.getTitle(), todo.getUser(), "add",
-					"", todo.getStatus());
-			case REMOVE:
-				return new History(todo.getId(), todo.getTitle(), todo.getUser(), "remove",
-					"", todo.getStatus());
-			case MOVE:
-			case UPDATE:
-				break;
-		}
-		return null;
+		return action.createHistoryBy(todo);
 	}
 
 }

--- a/BE/src/main/java/codesquad/be/todoserver/domain/History.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/History.java
@@ -40,9 +40,19 @@ public class History {
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public static History createAddHistoryBy(Todo todo) {
-		return new History(todo.getId(), todo.getTitle(), todo.getUser(), "add",
-			"", todo.getStatus());
+	public static History of(Todo todo, Action action) {
+		switch (action) {
+			case ADD:
+				return new History(todo.getId(), todo.getTitle(), todo.getUser(), "add",
+					"", todo.getStatus());
+			case REMOVE:
+				return new History(todo.getId(), todo.getTitle(), todo.getUser(), "remove",
+					"", todo.getStatus());
+			case MOVE:
+			case UPDATE:
+				break;
+		}
+		return null;
 	}
 
 }

--- a/BE/src/main/java/codesquad/be/todoserver/domain/History.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/History.java
@@ -1,6 +1,5 @@
 package codesquad.be.todoserver.domain;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
@@ -14,7 +13,6 @@ public class History {
 	private final String action;
 	private final String fromStatus;
 	private final String toStatus;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 	private final LocalDateTime createdAt;
 
 	public History(Long id, Long todoId, String todoTitle, String user, String action,

--- a/BE/src/main/java/codesquad/be/todoserver/domain/Todo.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/Todo.java
@@ -1,6 +1,5 @@
 package codesquad.be.todoserver.domain;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,9 +13,7 @@ public class Todo {
 	private final String contents;
 	private final String user;
 	private final String status;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime createdAt;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime updatedAt;
 
 	public Todo(Long id, String title, String contents, String user, String status) {

--- a/BE/src/main/java/codesquad/be/todoserver/repository/HistoryJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/HistoryJdbcRepository.java
@@ -40,7 +40,7 @@ public class HistoryJdbcRepository implements HistoryRepository {
 			ps.setString(4, history.getAction());
 			ps.setString(5, history.getFromStatus());
 			ps.setString(6, history.getToStatus());
-			ps.setDate(7, java.sql.Date.valueOf(history.getCreatedAt().toLocalDate()));
+			ps.setTimestamp(7, java.sql.Timestamp.valueOf(history.getCreatedAt()));
 			return ps;
 		});
 	}

--- a/BE/src/main/java/codesquad/be/todoserver/repository/HistoryJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/HistoryJdbcRepository.java
@@ -20,14 +20,14 @@ public class HistoryJdbcRepository implements HistoryRepository {
 
 
 	@Override
-	public List<History> findAllHistory() {
+	public List<History> findAll() {
 		String sql = "SELECT id, todo_id, todo_title, user, action, from_status, to_status, created_at FROM HISTORY";
 
 		return jdbcTemplate.query(sql, historyRowMapper());
 	}
 
 	@Override
-	public void saveHistory(History history) {
+	public void save(History history) {
 		String sql =
 			"INSERT INTO HISTORY (todo_id, todo_title, user, action, from_status, to_status, created_at)"
 				+ " VALUES (?, ?, ?, ?, ?, ?, ?)";

--- a/BE/src/main/java/codesquad/be/todoserver/repository/HistoryRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/HistoryRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface HistoryRepository {
 
-	List<History> findAllHistory();
+	List<History> findAll();
 
-	void saveHistory(History history);
+	void save(History history);
 }

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -46,8 +46,8 @@ public class TodoJdbcRepository implements TodoRepository {
 			ps.setString(2, todo.getContents());
 			ps.setString(3, todo.getUser());
 			ps.setString(4, todo.getStatus());
-			ps.setDate(5, java.sql.Date.valueOf(todo.getCreatedAt().toLocalDate()));
-			ps.setDate(6, java.sql.Date.valueOf(todo.getUpdatedAt().toLocalDate()));
+			ps.setTimestamp(5, java.sql.Timestamp.valueOf(todo.getCreatedAt()));
+			ps.setTimestamp(6, java.sql.Timestamp.valueOf(todo.getUpdatedAt()));
 			return ps;
 		}, keyHolder);
 		todo.setId(Objects.requireNonNull(keyHolder.getKey()).longValue());

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -29,14 +29,14 @@ public class TodoJdbcRepository implements TodoRepository {
 	}
 
 	@Override
-	public List<Todo> findAllTodos() {
+	public List<Todo> findAll() {
 		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO WHERE DELETED = 0";
 		List<Todo> todos = jdbcTemplate.query(sql, todoRowMapper());
 		return todos;
 	}
 
 	@Override
-	public Todo saveTodo(Todo todo) {
+	public Todo save(Todo todo) {
 		String sql = "INSERT INTO TODO (TITLE, CONTENTS, USER, STATUS, CREATED_AT, UPDATED_AT) VALUES (?, ?, ?, ?, ?, ?)";
 
 		KeyHolder keyHolder = new GeneratedKeyHolder();

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -22,7 +22,7 @@ public class TodoJdbcRepository implements TodoRepository {
 
 	@Override
 	public Optional<Todo> findById(Long id) {
-		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO WHERE id = ?";
+		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO WHERE id = ? AND DELETED = 0";
 		List<Todo> todos = jdbcTemplate.query(sql, todoRowMapper(), id);
 
 		return todos.stream().findAny();
@@ -30,7 +30,7 @@ public class TodoJdbcRepository implements TodoRepository {
 
 	@Override
 	public List<Todo> findAllTodos() {
-		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO";
+		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO WHERE DELETED = 0";
 		List<Todo> todos = jdbcTemplate.query(sql, todoRowMapper());
 		return todos;
 	}
@@ -57,8 +57,8 @@ public class TodoJdbcRepository implements TodoRepository {
 
 	@Override
 	public boolean deleteById(Long id) {
-		// 구현 중
-		return false;
+		String sql = "UPDATE TODO SET deleted = 1 WHERE id = ?";
+		return jdbcTemplate.update(sql, id) == 1;
 	}
 
 	public RowMapper<Todo> todoRowMapper() {

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -55,6 +55,12 @@ public class TodoJdbcRepository implements TodoRepository {
 		return todo;
 	}
 
+	@Override
+	public boolean deleteById(Long id) {
+		// 구현 중
+		return false;
+	}
+
 	public RowMapper<Todo> todoRowMapper() {
 		return (rs, rowNum) -> {
 			Todo todo = new Todo(

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
@@ -10,9 +10,9 @@ public interface TodoRepository {
 
 	Optional<Todo> findById(Long id);
 
-	List<Todo> findAllTodos();
+	List<Todo> findAll();
 
-	Todo saveTodo(Todo todo);
+	Todo save(Todo todo);
 
 	boolean deleteById(Long id);
 }

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
@@ -13,4 +13,6 @@ public interface TodoRepository {
 	List<Todo> findAllTodos();
 
 	Todo saveTodo(Todo todo);
+
+	boolean deleteById(Long id);
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/HistoryService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/HistoryService.java
@@ -18,7 +18,7 @@ public class HistoryService {
 	}
 
 	public List<History> getAllHistory() {
-		List<History> histories = historyRepository.findAllHistory();
+		List<History> histories = historyRepository.findAll();
 
 		if (histories.isEmpty()) {
 			throw new NoSuchElementException("Empty History");

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -30,7 +30,7 @@ public class TodoService {
 	}
 
 	public List<Todo> findTodos() {
-		List<Todo> todos = todoRepository.findAllTodos();
+		List<Todo> todos = todoRepository.findAll();
 
 		if (todos.isEmpty()) {
 			throw new NoSuchElementException("Empty Todos");
@@ -39,18 +39,18 @@ public class TodoService {
 	}
 
 	public Todo registerTodo(RegisterTodoDto registerTodoDto) {
-		Todo saveTodo = todoRepository.saveTodo(
+		Todo todo = todoRepository.save(
 			TodoDtoMapper.toDomainFromRegisterTodoDto(registerTodoDto));
 
-		historyRepository.saveHistory(History.of(saveTodo, Action.ADD));
-		return saveTodo;
+		historyRepository.save(History.of(todo, Action.ADD));
+		return todo;
 	}
 
 	public boolean deleteById(Long id) {
 		Todo todo = todoRepository.findById(id)
 			.orElseThrow(() -> new NoSuchTodoFoundException("id: " + id));
 
-		historyRepository.saveHistory(History.of(todo, Action.REMOVE));
+		historyRepository.save(History.of(todo, Action.REMOVE));
 		return todoRepository.deleteById(id);
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -47,7 +47,8 @@ public class TodoService {
 	}
 
 	public boolean deleteById(Long id) {
-			// 구현 중
-		return false;
+		todoRepository.findById(id)
+			.orElseThrow(() -> new NoSuchTodoFoundException("id: " + id));
+		return todoRepository.deleteById(id);
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -45,4 +45,9 @@ public class TodoService {
 		historyRepository.saveHistory(history);
 		return saveTodo;
 	}
+
+	public boolean deleteById(Long id) {
+			// 구현 중
+		return false;
+	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -2,6 +2,7 @@ package codesquad.be.todoserver.service;
 
 import codesquad.be.todoserver.controller.TodoDtoMapper;
 import codesquad.be.todoserver.controller.model.RegisterTodoDto;
+import codesquad.be.todoserver.domain.Action;
 import codesquad.be.todoserver.domain.History;
 import codesquad.be.todoserver.domain.Todo;
 import codesquad.be.todoserver.exception.NoSuchTodoFoundException;
@@ -41,14 +42,15 @@ public class TodoService {
 		Todo saveTodo = todoRepository.saveTodo(
 			TodoDtoMapper.toDomainFromRegisterTodoDto(registerTodoDto));
 
-		History history = History.createAddHistoryBy(saveTodo);
-		historyRepository.saveHistory(history);
+		historyRepository.saveHistory(History.of(saveTodo, Action.ADD));
 		return saveTodo;
 	}
 
 	public boolean deleteById(Long id) {
-		todoRepository.findById(id)
+		Todo todo = todoRepository.findById(id)
 			.orElseThrow(() -> new NoSuchTodoFoundException("id: " + id));
+
+		historyRepository.saveHistory(History.of(todo, Action.REMOVE));
 		return todoRepository.deleteById(id);
 	}
 }

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -17,3 +17,10 @@ logging:
   level:
     web: DEBUG
 
+# 배포용
+#spring:
+#  datasource:
+#    driverClassName: com.mysql.cj.jdbc.Driver
+#    url: jdbc:mysql://localhost:3306/TODO_APP
+#    username: donggi
+#    password: Donggikukim!

--- a/BE/src/main/resources/db/data.sql
+++ b/BE/src/main/resources/db/data.sql
@@ -1,6 +1,6 @@
 INSERT INTO TODO (TITLE, CONTENTS, USER, STATUS, CREATED_AT, UPDATED_AT)
 VALUES ('Github 공부하기', 'add, commit, push', 'sam', 'doing', '2022-04-06T15:30:00.000+09:00',
-        '2022-04-06T15:30:00.000+09:00'),
+        '2022-04-06T16:30:00.000+09:00'),
        ('블로그에 포스팅할 것', '*Github 공부내용 \r\n *모던 자바스크립트 1장 공부내용', 'sam', 'todo',
         '2022-04-07T15:30:00.000+09:00', '2022-04-07T15:30:00.000+09:00'),
        ('HTMl/CSS 공부하기', 'input 태그 실습', 'sam', 'doing', '2022-04-07T20:30:00.000+09:00',
@@ -10,4 +10,7 @@ VALUES ('Github 공부하기', 'add, commit, push', 'sam', 'doing', '2022-04-06T
 
 INSERT INTO HISTORY (TODO_ID, TODO_TITLE, USER, ACTION, FROM_STATUS, TO_STATUS, CREATED_AT)
 VALUES (1, 'Github 공부하기', 'sam', 'add', '', 'todo', '2022-04-06T15:30:00.000+09:00'),
+       (2, '블로그에 포스팅할 것', 'sam', 'add', '', 'todo', '2022-04-07T15:30:00.000+09:00'),
+       (3, 'HTMl/CSS 공부하기', 'sam', 'add', '', 'todo', '2022-04-07T20:30:00.000+09:00'),
+       (4, '여자친구와 데이트', 'sam', 'add', '', 'todo', '2022-04-08T15:30:00.000+09:00'),
        (1, 'Github 공부하기', 'sam', 'move', 'todo', 'doing', '2022-04-06T16:30:00.000+09:00');

--- a/BE/src/main/resources/db/schema.sql
+++ b/BE/src/main/resources/db/schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE TODO
     status       VARCHAR(10)                    COMMENT 'Todo의 상태(todo, doing, done)',
     created_at   TIMESTAMP                      COMMENT 'Todo 생성 시간',
     updated_at   TIMESTAMP                      COMMENT 'Todo 업데이트 시간',
+    deleted      BIT NOT NULL DEFAULT 0         COMMENT 'Todo 삭제 여부',
     PRIMARY KEY (id)
 );
 

--- a/BE/src/test/java/codesquad/be/todoserver/HistoriesApiAcceptanceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/HistoriesApiAcceptanceTest.java
@@ -41,13 +41,6 @@ class HistoriesApiAcceptanceTest {
 			.andExpect(jsonPath("$.[0].id").value(1))
 			.andExpect(jsonPath("$.[0].todoId").value(1))
 			.andExpect(jsonPath("$.[0].todoTitle").value("Github 공부하기"))
-			.andExpect(jsonPath("$.[0].action").value("add"))
-
-			.andExpect(jsonPath("$.[1].id").value(2))
-			.andExpect(jsonPath("$.[1].todoId").value(1))
-			.andExpect(jsonPath("$.[1].todoTitle").value("Github 공부하기"))
-			.andExpect(jsonPath("$.[1].action").value("move"))
-			.andExpect(jsonPath("$.[1].fromStatus").value("todo"))
-			.andExpect(jsonPath("$.[1].toStatus").value("doing"));
+			.andExpect(jsonPath("$.[0].action").value("add"));
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
@@ -1,6 +1,7 @@
 package codesquad.be.todoserver.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -64,6 +65,18 @@ class TodoControllerTest {
 		perform
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+	}
+
+	@Test
+	void 특정_투두_삭제_성공() throws Exception {
+		List<Todo> todos = createTestData();
+
+		given(todoService.getById(1L))
+			.willReturn(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
+
+		ResultActions perform = mockMvc.perform(delete("/api/todos/1"));
+
+		perform.andExpect(status().isNoContent());
 	}
 
 	private List<Todo> createTestData() {

--- a/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
@@ -47,7 +47,7 @@ class TodoRepositoryTest {
 
 	@Test
 	void 전체_투두리스트_조회_성공() {
-		List<Todo> todos = todoRepository.findAllTodos();
+		List<Todo> todos = todoRepository.findAll();
 
 		assertThat(todos).hasSize(4);
 	}

--- a/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
@@ -51,4 +51,11 @@ class TodoRepositoryTest {
 
 		assertThat(todos).hasSize(4);
 	}
+
+	@Test
+	void 특정_투두_삭제_성공() {
+		boolean result = todoRepository.deleteById(1L);
+
+		assertThat(result).isTrue();
+	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
@@ -56,7 +56,7 @@ class TodoServiceTest {
 	void 전체_투두리스트_조회_성공() {
 		List<Todo> todolist = createTestData();
 
-		given(todoRepository.findAllTodos())
+		given(todoRepository.findAll())
 			.willReturn(todolist);
 
 		List<Todo> todos = todoService.findTodos();

--- a/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
@@ -65,6 +65,18 @@ class TodoServiceTest {
 		assertThat(todos).contains(todolist.get(1));
 	}
 
+	@Test
+	void 특정_투두_삭제_성공() {
+		given(todoRepository.findById(2L))
+			.willReturn(Optional.of(new Todo(2L, "Github 공부하기", "add, commit, push", "sam", "todo")));
+		given(todoRepository.deleteById(2L))
+			.willReturn(true);
+
+		boolean result = todoService.deleteById(2L);
+
+		assertThat(result).isTrue();
+	}
+
 	private List<Todo> createTestData() {
 		List<Todo> todolist = new ArrayList<>();
 		todolist.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));

--- a/BE/src/test/resources/testDB/data.sql
+++ b/BE/src/test/resources/testDB/data.sql
@@ -1,6 +1,6 @@
 INSERT INTO TODO (TITLE, CONTENTS, USER, STATUS, CREATED_AT, UPDATED_AT)
 VALUES ('Github 공부하기', 'add, commit, push', 'sam', 'doing', '2022-04-06T15:30:00.000+09:00',
-        '2022-04-06T15:30:00.000+09:00'),
+        '2022-04-06T16:30:00.000+09:00'),
        ('블로그에 포스팅할 것', '*Github 공부내용 \r\n *모던 자바스크립트 1장 공부내용', 'sam', 'todo',
         '2022-04-07T15:30:00.000+09:00', '2022-04-07T15:30:00.000+09:00'),
        ('HTMl/CSS 공부하기', 'input 태그 실습', 'sam', 'doing', '2022-04-07T20:30:00.000+09:00',
@@ -10,4 +10,7 @@ VALUES ('Github 공부하기', 'add, commit, push', 'sam', 'doing', '2022-04-06T
 
 INSERT INTO HISTORY (TODO_ID, TODO_TITLE, USER, ACTION, FROM_STATUS, TO_STATUS, CREATED_AT)
 VALUES (1, 'Github 공부하기', 'sam', 'add', '', 'todo', '2022-04-06T15:30:00.000+09:00'),
+       (2, '블로그에 포스팅할 것', 'sam', 'add', '', 'todo', '2022-04-07T15:30:00.000+09:00'),
+       (3, 'HTMl/CSS 공부하기', 'sam', 'add', '', 'todo', '2022-04-07T20:30:00.000+09:00'),
+       (4, '여자친구와 데이트', 'sam', 'add', '', 'todo', '2022-04-08T15:30:00.000+09:00'),
        (1, 'Github 공부하기', 'sam', 'move', 'todo', 'doing', '2022-04-06T16:30:00.000+09:00');

--- a/BE/src/test/resources/testDB/schema.sql
+++ b/BE/src/test/resources/testDB/schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE TODO
     status       VARCHAR(10)                    COMMENT 'Todo의 상태(todo, doing, done)',
     created_at   TIMESTAMP                      COMMENT 'Todo 생성 시간',
     updated_at   TIMESTAMP                      COMMENT 'Todo 업데이트 시간',
+    deleted      BIT NOT NULL DEFAULT 0         COMMENT 'Todo 삭제 여부',
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
안녕하세요 `Dan` `동기`와 `쿠킴`입니다!
Todo 삭제하기 기능 구현하여 리뷰 요청드립니다. 빠르고 흥미로운 리뷰에 항상 감사합니다 🤤

### 📝 Description

| 요청 | 기능 |
| --- | --- |
| `DELETE /api/todos/{id}` | 클라이언트가 특정 Todo를 삭제한다. (soft delete) |

### 💽 Commits

- DELETE /api/todos/{id} 요청 값을 받는다.
- DB 에서 해당 id todo 를 찾아온다.
- 해당 todo 를 simple delete 하기 위해 삭제 유무 상태를 변경한다.
- 상태 코드만 반환한다. (204 No Contents)
- DELETE /api/todos/{id} 에 대한 History 저장
- 삭제 기능에 대한 web 계층 테스트 코드
- JsonFormat -> WebConfig 설정으로 변경

### 🖼 결과

<img width="422" alt="Screen Shot 2022-04-14 at 11 48 22 AM" src="https://user-images.githubusercontent.com/73376468/163303900-fce1f8c8-6a42-4784-90d4-78c886365cc1.png">
